### PR TITLE
Initial rumble support for DualSense and DualShock 4

### DIFF
--- a/bluetooth-mitm/source/controllers/dualsense_controller.cpp
+++ b/bluetooth-mitm/source/controllers/dualsense_controller.cpp
@@ -157,8 +157,18 @@ namespace ams::controller {
         m_buttons.home    = buttons->ps;
     }
 
+    Result DualsenseController::HandleRumbleReport(const bluetooth::HidReport *report)
+    {
+        auto rumble_report = reinterpret_cast<const SwitchReportData *>(&report->data);
+
+        m_rumble_high = ((rumble_report->output0x10.left_rumble.high_amp & 0xfe) + (rumble_report->output0x10.right_rumble.high_amp & 0xfe)) / 2;
+        m_rumble_low  = ((rumble_report->output0x10.left_rumble.low_amp  - 0x40) + (rumble_report->output0x10.right_rumble.low_amp  - 0x40)) / 2;
+
+        return PushRumbleLedState();
+    }
+
     Result DualsenseController::PushRumbleLedState(void) {
-        DualsenseOutputReport0x31 report = {0xa2, 0x31, 0x02, 0x00, 0x14};
+        DualsenseOutputReport0x31 report = {0xa2, 0x31, 0x02, 0x03, 0x14, m_rumble_high, m_rumble_low};
         report.data[41] = 0x02;
         report.data[44] = 0x02;
         report.data[46] = m_led_flags;

--- a/bluetooth-mitm/source/controllers/dualsense_controller.hpp
+++ b/bluetooth-mitm/source/controllers/dualsense_controller.hpp
@@ -110,13 +110,15 @@ namespace ams::controller {
             };  
 
             DualsenseController(const bluetooth::Address *address) 
-                : EmulatedSwitchController(address), m_led_flags(0), m_led_colour({0, 0, 0}) { };
+                : EmulatedSwitchController(address), m_rumble_high(0), m_rumble_low(0), m_led_flags(0), m_led_colour({0, 0, 0}) { };
 
             Result Initialize(void);
             Result SetPlayerLed(uint8_t led_mask);
             Result SetLightbarColour(RGBColour colour);
 
             void UpdateControllerState(const bluetooth::HidReport *report);
+
+            Result HandleRumbleReport(const bluetooth::HidReport *report);
 
         private:
             void HandleInputReport0x01(const DualsenseReportData *src);
@@ -125,6 +127,9 @@ namespace ams::controller {
             void MapButtons(const DualsenseButtonData *buttons);
 
             Result PushRumbleLedState(void);
+
+            uint8_t m_rumble_high;
+            uint8_t m_rumble_low;
 
             uint8_t m_led_flags;
             RGBColour m_led_colour;

--- a/bluetooth-mitm/source/controllers/dualshock4_controller.hpp
+++ b/bluetooth-mitm/source/controllers/dualshock4_controller.hpp
@@ -125,13 +125,15 @@ namespace ams::controller {
             };
 
             Dualshock4Controller(const bluetooth::Address *address)
-                : EmulatedSwitchController(address), m_led_colour({0, 0, 0}) { };
+                : EmulatedSwitchController(address), m_rumble_high(0), m_rumble_low(0), m_led_colour({0, 0, 0}) { };
             
             Result Initialize(void);
             Result SetPlayerLed(uint8_t led_mask);
             Result SetLightbarColour(RGBColour colour);
             
             void UpdateControllerState(const bluetooth::HidReport *report);
+
+            Result HandleRumbleReport(const bluetooth::HidReport *report);
 
         private:
             void HandleInputReport0x01(const Dualshock4ReportData *src);
@@ -140,6 +142,9 @@ namespace ams::controller {
             void MapButtons(const Dualshock4ButtonData *buttons);
             
             Result PushRumbleLedState(void);
+
+            uint8_t m_rumble_high;
+            uint8_t m_rumble_low;
 
             RGBColour m_led_colour; 
     };

--- a/bluetooth-mitm/source/controllers/emulated_switch_controller.cpp
+++ b/bluetooth-mitm/source/controllers/emulated_switch_controller.cpp
@@ -83,7 +83,8 @@ namespace ams::controller {
                 R_TRY(this->HandleSubCmdReport(report));
                 break;
             case 0x10:  // Rumble
-                // Todo: add rumble support
+                R_TRY(this->HandleRumbleReport(report));
+                break;
             default:
                 break;
         }

--- a/bluetooth-mitm/source/controllers/emulated_switch_controller.hpp
+++ b/bluetooth-mitm/source/controllers/emulated_switch_controller.hpp
@@ -42,6 +42,8 @@ namespace ams::controller {
                 };
             }
 
+            virtual Result HandleRumbleReport(const bluetooth::HidReport *report) { return ams::ResultSuccess(); };
+
             Result HandleSubCmdReport(const bluetooth::HidReport *report);
             Result SubCmdRequestDeviceInfo(const bluetooth::HidReport *report);
             Result SubCmdSpiFlashRead(const bluetooth::HidReport *report);

--- a/bluetooth-mitm/source/controllers/switch_controller.hpp
+++ b/bluetooth-mitm/source/controllers/switch_controller.hpp
@@ -52,7 +52,14 @@ namespace ams::controller {
         RGBColour left_grip;
         RGBColour right_grip;
     } __attribute__ ((__packed__));
-        
+
+    struct SwitchRumbleData {
+        uint8_t high_freq;
+        uint8_t high_amp;
+        uint8_t low_freq;
+        uint8_t low_amp;
+    } __attribute__ ((__packed__));
+
     struct SwitchStickData {
         uint8_t xy[3];
     } __attribute__ ((__packed__));
@@ -129,7 +136,12 @@ namespace ams::controller {
 
     struct SwitchOutputReport0x01;
     struct SwitchOutputReport0x03;
-    struct SwitchOutputReport0x10;
+
+    struct SwitchOutputReport0x10 {
+        SwitchRumbleData left_rumble;
+        SwitchRumbleData right_rumble;
+    } __attribute__ ((__packed__));
+
     struct SwitchOutputReport0x11;
     struct SwitchOutputReport0x12;
 
@@ -169,7 +181,7 @@ namespace ams::controller {
         union {
             //SwitchOutputReport0x01 output0x01;
             //SwitchOutputReport0x03 output0x03;
-            //SwitchOutputReport0x10 output0x10;
+            SwitchOutputReport0x10 output0x10;
             //SwitchOutputReport0x11 output0x11;
             //SwitchOutputReport0x12 output0x12;
             SwitchInputReport0x21  input0x21;


### PR DESCRIPTION
This is a naive implementation that basically just uses amplitude as the rumble intensity, but it works reasonably well in my testing. It might need further adjustments, and in the future the DualSense might be able to support actual HD rumble. I was also somewhat successful at getting rumble working on Xbox contollers, but there are some issues so it's not included here. As for other controllers... I don't really have them to test.