### PR TITLE
Support Wii U Pro Controller battery level and charging flag

### DIFF
--- a/mc_mitm/source/controllers/wii_controller.cpp
+++ b/mc_mitm/source/controllers/wii_controller.cpp
@@ -86,7 +86,9 @@ namespace ams::controller {
             this->ReadMemory(0x04a400fa, 6);
         }
 
-        m_battery = convert_battery_255(src->input0x20.battery);
+        if (m_extension != WiiExtensionController_WiiUPro) {
+            m_battery = convert_battery_255(src->input0x20.battery);
+        }
     }
 
     void WiiController::HandleInputReport0x21(const WiiReportData *src) {
@@ -299,6 +301,10 @@ namespace ams::controller {
         m_buttons.rstick_press = !extension->buttons.rstick_press;
 
         m_buttons.home = !extension->buttons.home;
+
+        m_charging = !extension->buttons.charging;
+
+        m_battery = (extension->buttons.battery == 0b111) ? 0 : (extension->buttons.battery << 1);
     }
 
     void WiiController::MapTaTaConExtension(const uint8_t ext[]) {

--- a/mc_mitm/source/controllers/wii_controller.hpp
+++ b/mc_mitm/source/controllers/wii_controller.hpp
@@ -111,9 +111,12 @@ namespace ams::controller {
         uint8_t B           : 1;
         uint8_t ZL          : 1;
 
-        uint8_t rstick_press : 1;
-        uint8_t lstick_press : 1;
-        uint8_t : 0;
+        uint8_t rstick_press  : 1;
+        uint8_t lstick_press  : 1;
+        uint8_t charging      : 1;
+        uint8_t usb_connected : 1;
+        uint8_t battery       : 3;
+        uint8_t               : 1;
     } __attribute__ ((__packed__));
 
     struct WiiUProExtensionData {


### PR DESCRIPTION
The Wii U Pro Controller doesn't seem to use the battery level in the status report. Instead it uses a 3 bit value in the button data and reports the battery level from 0 to 4.
It also has a flag for charging and if it's connected via a USB cable.

Tested and confirmed working on my Switch.