### PR TITLE
mc: update for Atmosphere-libs refactoring

### DIFF
--- a/mc_mitm/source/bluetooth_mitm/bluetooth/bluetooth_core.cpp
+++ b/mc_mitm/source/bluetooth_mitm/bluetooth/bluetooth_core.cpp
@@ -36,7 +36,7 @@ namespace ams::bluetooth::core {
         os::Event g_data_read_event(os::EventClearMode_AutoClear);
 
         bluetooth::Address ReverseBluetoothAddress(bluetooth::Address address) {
-            uint64_t tmp = util::SwapBytes48(*reinterpret_cast<uint64_t *>(&address)); 
+            uint64_t tmp = util::SwapBytes48(*reinterpret_cast<uint64_t *>(&address));
             return *reinterpret_cast<bluetooth::Address *>(&tmp);
         }
 
@@ -151,7 +151,7 @@ namespace ams::bluetooth::core {
         uint8_t pin_length = std::strlen(pin.code);
 
         // Reverse host address as pin code for wii devices
-        if (std::strncmp(g_event_info.pairing_pin_code_request.name, controller::wii_controller_prefix, std::strlen(controller::wii_controller_prefix)) == 0) {
+        if (std::strncmp(event_info->pairing_pin_code_request.name, controller::wii_controller_prefix, std::strlen(controller::wii_controller_prefix)) == 0) {
             // Fetch host adapter address
             bluetooth::Address host_address;
             R_ABORT_UNLESS(btdrvLegacyGetAdapterProperty(BtdrvBluetoothPropertyType_Address, &host_address, sizeof(bluetooth::Address)));
@@ -161,7 +161,7 @@ namespace ams::bluetooth::core {
             pin_length = sizeof(bluetooth::Address);
         }
 
-        R_ABORT_UNLESS(btdrvLegacyRespondToPinRequest(g_event_info.pairing_pin_code_request.addr, false, &pin, pin_length));
+        R_ABORT_UNLESS(btdrvLegacyRespondToPinRequest(event_info->pairing_pin_code_request.addr, false, &pin, pin_length));
     }
 
     inline void HandlePinCodeRequestEventV12(bluetooth::EventInfo *event_info) {
@@ -169,7 +169,7 @@ namespace ams::bluetooth::core {
         BtdrvPinCode pin = {"0000", 4};
 
         // Reverse host address as pin code for wii devices
-        if (std::strncmp(g_event_info.pairing_pin_code_request.name, controller::wii_controller_prefix, std::strlen(controller::wii_controller_prefix)) == 0) {
+        if (std::strncmp(event_info->pairing_pin_code_request.name, controller::wii_controller_prefix, std::strlen(controller::wii_controller_prefix)) == 0) {
             // Fetch host adapter address
             BtdrvAdapterProperty property;
             R_ABORT_UNLESS(btdrvGetAdapterProperty(BtdrvAdapterPropertyType_Address, &property));
@@ -181,7 +181,7 @@ namespace ams::bluetooth::core {
             pin.length = sizeof(bluetooth::Address);
         }
 
-        R_ABORT_UNLESS(btdrvRespondToPinRequest(g_event_info.pairing_pin_code_request.addr, &pin));
+        R_ABORT_UNLESS(btdrvRespondToPinRequest(event_info->pairing_pin_code_request.addr, &pin));
     }
 
     void HandleEvent(void) {

--- a/mc_mitm/source/bluetooth_mitm/bluetoothmitm_module.cpp
+++ b/mc_mitm/source/bluetooth_mitm/bluetoothmitm_module.cpp
@@ -30,9 +30,11 @@ namespace ams::mitm::bluetooth {
         constexpr sm::ServiceName BtdrvMitmServiceName = sm::ServiceName::Encode("btdrv");
 
         struct ServerOptions {
-            static constexpr size_t PointerBufferSize = 0x1000;
-            static constexpr size_t MaxDomains = 0;
-            static constexpr size_t MaxDomainObjects = 0;
+            static constexpr size_t PointerBufferSize   = 0x1000;
+            static constexpr size_t MaxDomains          = 0;
+            static constexpr size_t MaxDomainObjects    = 0;
+            static constexpr bool CanDeferInvokeRequest = false;
+            static constexpr bool CanManageMitmServers  = true;
         };
 
         constexpr size_t MaxSessions = 6;

--- a/mc_mitm/source/bluetooth_mitm/bluetoothmitm_module.cpp
+++ b/mc_mitm/source/bluetooth_mitm/bluetoothmitm_module.cpp
@@ -61,7 +61,7 @@ namespace ams::mitm::bluetooth {
         alignas(os::ThreadStackAlignment) u8 g_btdrv_mitm_thread_stack[0x2000];
         s32 g_btdrv_mitm_thread_priority = utils::ConvertToUserPriority(17);
 
-        void BtdrvMitmThreadFunction(void *arg) {
+        void BtdrvMitmThreadFunction(void *) {
             R_ABORT_UNLESS((g_server_manager.RegisterMitmServer<BtdrvMitmService>(PortIndex_BtdrvMitm, BtdrvMitmServiceName)));
             g_server_manager.LoopProcess();
         }

--- a/mc_mitm/source/bluetooth_mitm/btdrv_mitm_service.cpp
+++ b/mc_mitm/source/bluetooth_mitm/btdrv_mitm_service.cpp
@@ -30,7 +30,7 @@ namespace ams::mitm::bluetooth {
         if (!ams::bluetooth::core::IsInitialized()) {
             // Forward to the real function to obtain the system event handle
             os::NativeHandle handle = os::InvalidNativeHandle;
-            R_TRY(btdrvInitializeBluetoothFwd(this->forward_service.get(), &handle));
+            R_TRY(btdrvInitializeBluetoothFwd(m_forward_service.get(), &handle));
 
             // Attach the real system event handle to our own event
             ams::bluetooth::core::GetSystemEvent()->AttachReadableHandle(handle, false, os::EventClearMode_ManualClear);
@@ -51,7 +51,7 @@ namespace ams::mitm::bluetooth {
     }
 
     Result BtdrvMitmService::EnableBluetooth(void) {
-        R_TRY(btdrvEnableBluetoothFwd(this->forward_service.get()));
+        R_TRY(btdrvEnableBluetoothFwd(m_forward_service.get()));
         ams::bluetooth::core::SignalEnabled();
 
         // Wait until mc.mitm module initialisation has completed before returning
@@ -61,7 +61,7 @@ namespace ams::mitm::bluetooth {
     }
 
     Result BtdrvMitmService::GetEventInfo(sf::Out<ams::bluetooth::EventType> out_type, const sf::OutPointerBuffer &out_buffer) {
-        R_TRY(ams::bluetooth::core::GetEventInfo(this->client_info.program_id,
+        R_TRY(ams::bluetooth::core::GetEventInfo(m_client_info.program_id,
             out_type.GetPointer(),
             static_cast<uint8_t *>(out_buffer.GetPointer()),
             static_cast<size_t>(out_buffer.GetSize())
@@ -74,7 +74,7 @@ namespace ams::mitm::bluetooth {
         if (!ams::bluetooth::hid::IsInitialized()) {
             // Forward to the real function to obtain the system event handle
             os::NativeHandle handle = os::InvalidNativeHandle;
-            R_TRY(btdrvInitializeHidFwd(this->forward_service.get(), &handle, version));
+            R_TRY(btdrvInitializeHidFwd(m_forward_service.get(), &handle, version));
 
             // Attach the real system event handle to our own event
             ams::bluetooth::hid::GetSystemEvent()->AttachReadableHandle(handle, false, os::EventClearMode_ManualClear);
@@ -95,14 +95,14 @@ namespace ams::mitm::bluetooth {
     Result BtdrvMitmService::WriteHidData(ams::bluetooth::Address address, const sf::InPointerBuffer &buffer) {
         auto report = reinterpret_cast<const ams::bluetooth::HidReport *>(buffer.GetPointer());
 
-        if (this->client_info.program_id == ncm::SystemProgramId::Hid) {
+        if (m_client_info.program_id == ncm::SystemProgramId::Hid) {
             auto device = controller::LocateHandler(&address);
             if (device) {
                 device->HandleOutgoingReport(report);
             }
         }
         else {
-            R_TRY(btdrvWriteHidDataFwd(this->forward_service.get(), &address, report));
+            R_TRY(btdrvWriteHidDataFwd(m_forward_service.get(), &address, report));
         }
 
         return ams::ResultSuccess();
@@ -164,8 +164,8 @@ namespace ams::mitm::bluetooth {
     Result BtdrvMitmService::RegisterHidReportEvent(sf::OutCopyHandle out_handle) {
         if (!ams::bluetooth::hid::report::IsInitialized()) {
             os::NativeHandle handle = os::InvalidNativeHandle;
-            R_TRY(btdrvRegisterHidReportEventFwd(this->forward_service.get(), &handle));
-            R_TRY(ams::bluetooth::hid::report::Initialize(handle, this->forward_service.get(), os::GetThreadId(os::GetCurrentThread())));
+            R_TRY(btdrvRegisterHidReportEventFwd(m_forward_service.get(), &handle));
+            R_TRY(ams::bluetooth::hid::report::Initialize(handle, m_forward_service.get(), os::GetThreadId(os::GetCurrentThread())));
             out_handle.SetValue(ams::bluetooth::hid::report::GetForwardEvent()->GetReadableHandle(), false);
         }
         else {
@@ -189,18 +189,18 @@ namespace ams::mitm::bluetooth {
 
     /* 1.0.0 - 3.0.2 */
     Result BtdrvMitmService::GetHidReportEventInfoDeprecated1(sf::Out<ams::bluetooth::HidEventType> out_type, const sf::OutPointerBuffer &out_buffer) {
-        return _GetHidReportEventInfoDeprecated(this->forward_service.get(), out_type, out_buffer);
+        return _GetHidReportEventInfoDeprecated(m_forward_service.get(), out_type, out_buffer);
     }
 
     /* 4.0.0 - 6.2.0 */
     Result BtdrvMitmService::GetHidReportEventInfoDeprecated2(sf::Out<ams::bluetooth::HidEventType> out_type, const sf::OutPointerBuffer &out_buffer) {
-        return _GetHidReportEventInfoDeprecated(this->forward_service.get(), out_type, out_buffer);
+        return _GetHidReportEventInfoDeprecated(m_forward_service.get(), out_type, out_buffer);
     }
 
     /* 7.0.0+ */
     Result BtdrvMitmService::GetHidReportEventInfo(sf::OutCopyHandle out_handle) {
         os::NativeHandle handle = os::InvalidNativeHandle;
-        R_TRY(btdrvGetHidReportEventInfoFwd(this->forward_service.get(), &handle));
+        R_TRY(btdrvGetHidReportEventInfoFwd(m_forward_service.get(), &handle));
         R_TRY(ams::bluetooth::hid::report::MapRemoteSharedMemory(handle));
         out_handle.SetValue(ams::bluetooth::hid::report::GetFakeSharedMemory()->handle, false);
 
@@ -211,7 +211,7 @@ namespace ams::mitm::bluetooth {
         if (!ams::bluetooth::ble::IsInitialized()) {
             // Forward to the real function to obtain the system event handle
             os::NativeHandle handle = os::InvalidNativeHandle;
-            R_TRY(btdrvInitializeBleFwd(this->forward_service.get(), &handle));
+            R_TRY(btdrvInitializeBleFwd(m_forward_service.get(), &handle));
 
             // Attach the real system event handle to our own event
             ams::bluetooth::ble::GetSystemEvent()->AttachReadableHandle(handle, false, os::EventClearMode_ManualClear);

--- a/mc_mitm/source/bluetooth_mitm/btdrv_mitm_service.hpp
+++ b/mc_mitm/source/bluetooth_mitm/btdrv_mitm_service.hpp
@@ -52,6 +52,7 @@ namespace ams::mitm::bluetooth {
 
         public:
             static bool ShouldMitm(const sm::MitmProcessInfo &client_info) {
+                AMS_UNUSED(client_info);
                 return true;
             }
 

--- a/mc_mitm/source/btm_mitm/btm/btm_types.hpp
+++ b/mc_mitm/source/btm_mitm/btm/btm_types.hpp
@@ -19,31 +19,31 @@
 
 namespace ams::btm {
 
-    struct DeviceConditionV100 : sf::LargeData {
+    struct DeviceConditionV100 : public sf::LargeData {
         BtmDeviceConditionV100 condition;
     };
 
-    struct DeviceConditionV510 : sf::LargeData {
+    struct DeviceConditionV510 : public sf::LargeData {
         BtmDeviceConditionV510 condition;
     };
 
-    struct DeviceConditionV800 : sf::LargeData {
+    struct DeviceConditionV800 : public sf::LargeData {
         BtmDeviceConditionV800 condition;
     };
 
-    struct DeviceConditionV900 : sf::LargeData {
+    struct DeviceConditionV900 : public sf::LargeData {
         BtmDeviceConditionV900 condition;
     };
 
-    struct ConnectedDevice : sf::LargeData {
+    struct ConnectedDevice : public sf::LargeData {
         BtmConnectedDeviceV13 condition;
     };
 
-    struct DeviceInfo : sf::LargeData {
+    struct DeviceInfo : public sf::LargeData {
         BtmDeviceInfoV13 info;
     };
 
-    struct DeviceInfoList : sf::LargeData {
+    struct DeviceInfoList : public sf::LargeData {
         BtmDeviceInfoList info;
     };
 

--- a/mc_mitm/source/btm_mitm/btm_mitm_service.cpp
+++ b/mc_mitm/source/btm_mitm/btm_mitm_service.cpp
@@ -35,35 +35,35 @@ namespace ams::mitm::btm {
 
     Result BtmMitmService::GetDeviceConditionDeprecated1(sf::Out<ams::btm::DeviceConditionV100> out) {
         auto device_condition = reinterpret_cast<BtmDeviceConditionV100 *>(out.GetPointer());
-        R_TRY(btmGetDeviceConditionDeprecated1Fwd(this->forward_service.get(), device_condition));
+        R_TRY(btmGetDeviceConditionDeprecated1Fwd(m_forward_service.get(), device_condition));
         RenameConnectedDevices(device_condition->devices, device_condition->connected_count);
         return ams::ResultSuccess();
     }
 
     Result BtmMitmService::GetDeviceConditionDeprecated2(sf::Out<ams::btm::DeviceConditionV510> out) {
         auto device_condition = reinterpret_cast<BtmDeviceConditionV510 *>(out.GetPointer());
-        R_TRY(btmGetDeviceConditionDeprecated2Fwd(this->forward_service.get(), device_condition));
+        R_TRY(btmGetDeviceConditionDeprecated2Fwd(m_forward_service.get(), device_condition));
         RenameConnectedDevices(device_condition->devices, device_condition->connected_count);
         return ams::ResultSuccess();
     }
 
     Result BtmMitmService::GetDeviceConditionDeprecated3(sf::Out<ams::btm::DeviceConditionV800> out) {
         auto device_condition = reinterpret_cast<BtmDeviceConditionV800 *>(out.GetPointer());
-        R_TRY(btmGetDeviceConditionDeprecated3Fwd(this->forward_service.get(), device_condition));
+        R_TRY(btmGetDeviceConditionDeprecated3Fwd(m_forward_service.get(), device_condition));
         RenameConnectedDevices(device_condition->devices, device_condition->connected_count);
         return ams::ResultSuccess();
     }
 
     Result BtmMitmService::GetDeviceConditionDeprecated4(sf::Out<ams::btm::DeviceConditionV900> out) {
         auto device_condition = reinterpret_cast<BtmDeviceConditionV900 *>(out.GetPointer());
-        R_TRY(btmGetDeviceConditionDeprecated4Fwd(this->forward_service.get(), device_condition));
+        R_TRY(btmGetDeviceConditionDeprecated4Fwd(m_forward_service.get(), device_condition));
         RenameConnectedDevices(device_condition->devices, device_condition->connected_count);
         return ams::ResultSuccess();
     }
 
     Result BtmMitmService::GetDeviceCondition(u32 id, const sf::OutArray<ams::btm::ConnectedDevice> &out, sf::Out<s32> total_out) {
         auto device_condition = reinterpret_cast<BtmConnectedDeviceV13 *>(out.GetPointer());
-        R_TRY(btmGetDeviceConditionFwd(this->forward_service.get(), id, device_condition, out.GetSize(), total_out.GetPointer()));
+        R_TRY(btmGetDeviceConditionFwd(m_forward_service.get(), id, device_condition, out.GetSize(), total_out.GetPointer()));
 
         for (int i = 0; i < total_out.GetValue(); ++i) {
             auto device = &device_condition[i];
@@ -77,7 +77,7 @@ namespace ams::mitm::btm {
 
     Result BtmMitmService::GetDeviceInfoDeprecated(sf::Out<ams::btm::DeviceInfoList> out) {
         auto device_info = reinterpret_cast<BtmDeviceInfoList *>(out.GetPointer());
-        R_TRY(btmGetDeviceInfoDeprecatedFwd(this->forward_service.get(), device_info));
+        R_TRY(btmGetDeviceInfoDeprecatedFwd(m_forward_service.get(), device_info));
 
         for (unsigned int i = 0; i < device_info->device_count; ++i) {
             auto device = &device_info->devices[i];
@@ -91,7 +91,7 @@ namespace ams::mitm::btm {
 
     Result BtmMitmService::GetDeviceInfo(u32 id, const sf::OutArray<ams::btm::DeviceInfo> &out, sf::Out<s32> total_out) {
         auto device_info = reinterpret_cast<BtmDeviceInfoV13 *>(out.GetPointer());
-        R_TRY(btmGetDeviceInfoFwd(this->forward_service.get(), id, device_info, out.GetSize(), total_out.GetPointer()));
+        R_TRY(btmGetDeviceInfoFwd(m_forward_service.get(), id, device_info, out.GetSize(), total_out.GetPointer()));
 
         for (int i = 0; i < total_out.GetValue(); ++i) {
             auto device = &device_info[i];

--- a/mc_mitm/source/btm_mitm/btmmitm_module.cpp
+++ b/mc_mitm/source/btm_mitm/btmmitm_module.cpp
@@ -30,9 +30,11 @@ namespace ams::mitm::btm {
         constexpr sm::ServiceName BtmMitmServiceName = sm::ServiceName::Encode("btm");
 
         struct ServerOptions {
-            static constexpr size_t PointerBufferSize = 0x1000;
-            static constexpr size_t MaxDomains = 0;
-            static constexpr size_t MaxDomainObjects = 0;
+            static constexpr size_t PointerBufferSize   = 0x1000;
+            static constexpr size_t MaxDomains          = 0;
+            static constexpr size_t MaxDomainObjects    = 0;
+            static constexpr bool CanDeferInvokeRequest = false;
+            static constexpr bool CanManageMitmServers  = true;
         };
 
         constexpr size_t MaxSessions = 6;

--- a/mc_mitm/source/btm_mitm/btmmitm_module.cpp
+++ b/mc_mitm/source/btm_mitm/btmmitm_module.cpp
@@ -61,7 +61,7 @@ namespace ams::mitm::btm {
         alignas(os::ThreadStackAlignment) u8 g_btm_mitm_thread_stack[0x2000];
         s32 g_btm_mitm_thread_priority = utils::ConvertToUserPriority(37);
 
-        void BtmMitmThreadFunction(void *arg) {
+        void BtmMitmThreadFunction(void *) {
             R_ABORT_UNLESS((g_server_manager.RegisterMitmServer<BtmMitmService>(PortIndex_BtmMitm, BtmMitmServiceName)));
             g_server_manager.LoopProcess();
         }
@@ -76,7 +76,7 @@ namespace ams::mitm::btm {
             sizeof(g_btm_mitm_thread_stack),
             g_btm_mitm_thread_priority
         ));
-        
+
         os::StartThread(&g_btm_mitm_thread);
 
         return ams::ResultSuccess();

--- a/mc_mitm/source/controllers/controller_management.cpp
+++ b/mc_mitm/source/controllers/controller_management.cpp
@@ -94,12 +94,12 @@ namespace ams::controller {
                 return ControllerType_Gembox;
             }
         }
-				
+
         for (auto hwId : IpegaController::hardware_ids) {
             if ( (device->vid == hwId.vid) && (device->pid == hwId.pid) ) {
                 return ControllerType_Ipega;
             }
-        }  
+        }
 
         for (auto hwId : XiaomiController::hardware_ids) {
             if ( (device->vid == hwId.vid) && (device->pid == hwId.pid) ) {
@@ -124,7 +124,7 @@ namespace ams::controller {
                 return ControllerType_NvidiaShield;
 			}
 		}
-		
+
         for (auto hwId : EightBitDoController::hardware_ids) {
             if ( (device->vid == hwId.vid) && (device->pid == hwId.pid) ) {
                 return ControllerType_8BitDo;
@@ -160,7 +160,7 @@ namespace ams::controller {
                 return ControllerType_ICade;
             }
         }
-		
+
 		for (auto hwId : LanShenController::hardware_ids) {
             if ( (device->vid == hwId.vid) && (device->pid == hwId.pid) ) {
                 return ControllerType_LanShen;
@@ -172,7 +172,7 @@ namespace ams::controller {
                 return ControllerType_AtGames;
             }
         }
-		
+
         return ControllerType_Unknown;
     }
 

--- a/mc_mitm/source/controllers/emulated_switch_controller.cpp
+++ b/mc_mitm/source/controllers/emulated_switch_controller.cpp
@@ -31,23 +31,23 @@ namespace ams::controller {
         // Frequency in Hz rounded to nearest int
         // https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/rumble_data_table.md#frequency-table
         const uint16_t rumble_freq_lut[] = {
-            0x0029, 0x002a, 0x002b, 0x002c, 0x002d, 0x002e, 0x002f, 0x0030, 0x0031, 
-            0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037, 0x0039, 0x003a, 0x003b, 
-            0x003c, 0x003e, 0x003f, 0x0040, 0x0042, 0x0043, 0x0045, 0x0046, 0x0048, 
-            0x0049, 0x004b, 0x004d, 0x004e, 0x0050, 0x0052, 0x0054, 0x0055, 0x0057, 
-            0x0059, 0x005b, 0x005d, 0x005f, 0x0061, 0x0063, 0x0066, 0x0068, 0x006a, 
-            0x006c, 0x006f, 0x0071, 0x0074, 0x0076, 0x0079, 0x007b, 0x007e, 0x0081, 
-            0x0084, 0x0087, 0x0089, 0x008d, 0x0090, 0x0093, 0x0096, 0x0099, 0x009d, 
-            0x00a0, 0x00a4, 0x00a7, 0x00ab, 0x00ae, 0x00b2, 0x00b6, 0x00ba, 0x00be, 
-            0x00c2, 0x00c7, 0x00cb, 0x00cf, 0x00d4, 0x00d9, 0x00dd, 0x00e2, 0x00e7, 
-            0x00ec, 0x00f1, 0x00f7, 0x00fc, 0x0102, 0x0107, 0x010d, 0x0113, 0x0119, 
-            0x011f, 0x0125, 0x012c, 0x0132, 0x0139, 0x0140, 0x0147, 0x014e, 0x0155, 
-            0x015d, 0x0165, 0x016c, 0x0174, 0x017d, 0x0185, 0x018d, 0x0196, 0x019f, 
-            0x01a8, 0x01b1, 0x01bb, 0x01c5, 0x01ce, 0x01d9, 0x01e3, 0x01ee, 0x01f8, 
-            0x0203, 0x020f, 0x021a, 0x0226, 0x0232, 0x023e, 0x024b, 0x0258, 0x0265, 
-            0x0272, 0x0280, 0x028e, 0x029c, 0x02ab, 0x02ba, 0x02c9, 0x02d9, 0x02e9, 
-            0x02f9, 0x030a, 0x031b, 0x032c, 0x033e, 0x0350, 0x0363, 0x0376, 0x0389, 
-            0x039d, 0x03b1, 0x03c6, 0x03db, 0x03f1, 0x0407, 0x041d, 0x0434, 0x044c, 
+            0x0029, 0x002a, 0x002b, 0x002c, 0x002d, 0x002e, 0x002f, 0x0030, 0x0031,
+            0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037, 0x0039, 0x003a, 0x003b,
+            0x003c, 0x003e, 0x003f, 0x0040, 0x0042, 0x0043, 0x0045, 0x0046, 0x0048,
+            0x0049, 0x004b, 0x004d, 0x004e, 0x0050, 0x0052, 0x0054, 0x0055, 0x0057,
+            0x0059, 0x005b, 0x005d, 0x005f, 0x0061, 0x0063, 0x0066, 0x0068, 0x006a,
+            0x006c, 0x006f, 0x0071, 0x0074, 0x0076, 0x0079, 0x007b, 0x007e, 0x0081,
+            0x0084, 0x0087, 0x0089, 0x008d, 0x0090, 0x0093, 0x0096, 0x0099, 0x009d,
+            0x00a0, 0x00a4, 0x00a7, 0x00ab, 0x00ae, 0x00b2, 0x00b6, 0x00ba, 0x00be,
+            0x00c2, 0x00c7, 0x00cb, 0x00cf, 0x00d4, 0x00d9, 0x00dd, 0x00e2, 0x00e7,
+            0x00ec, 0x00f1, 0x00f7, 0x00fc, 0x0102, 0x0107, 0x010d, 0x0113, 0x0119,
+            0x011f, 0x0125, 0x012c, 0x0132, 0x0139, 0x0140, 0x0147, 0x014e, 0x0155,
+            0x015d, 0x0165, 0x016c, 0x0174, 0x017d, 0x0185, 0x018d, 0x0196, 0x019f,
+            0x01a8, 0x01b1, 0x01bb, 0x01c5, 0x01ce, 0x01d9, 0x01e3, 0x01ee, 0x01f8,
+            0x0203, 0x020f, 0x021a, 0x0226, 0x0232, 0x023e, 0x024b, 0x0258, 0x0265,
+            0x0272, 0x0280, 0x028e, 0x029c, 0x02ab, 0x02ba, 0x02c9, 0x02d9, 0x02e9,
+            0x02f9, 0x030a, 0x031b, 0x032c, 0x033e, 0x0350, 0x0363, 0x0376, 0x0389,
+            0x039d, 0x03b1, 0x03c6, 0x03db, 0x03f1, 0x0407, 0x041d, 0x0434, 0x044c,
             0x0464, 0x047d, 0x0496, 0x04af, 0x04ca, 0x04e5
         };
 
@@ -125,7 +125,7 @@ namespace ams::controller {
 
     }
 
-    EmulatedSwitchController::EmulatedSwitchController(const bluetooth::Address *address, HardwareID id) 
+    EmulatedSwitchController::EmulatedSwitchController(const bluetooth::Address *address, HardwareID id)
     : SwitchController(address, id)
     , m_charging(false)
     , m_ext_power(false)
@@ -148,7 +148,7 @@ namespace ams::controller {
 
     Result EmulatedSwitchController::Initialize(void) {
         char path[0x100] = {};
-        
+
         // Ensure config directory for this controller exists
         std::strcat(path, controller_base_path);
         utils::BluetoothAddressToString(&m_address, path+std::strlen(path), sizeof(path)-std::strlen(path));
@@ -278,7 +278,7 @@ namespace ams::controller {
             return ams::ResultSuccess();
 
         auto report_data = reinterpret_cast<const SwitchReportData *>(report->data);
-        
+
         SwitchRumbleData rumble_data;
         DecodeRumbleValues(report_data->output0x10.rumble.left_motor, &rumble_data);
 
@@ -286,6 +286,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdRequestDeviceInfo(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x82,
             .id = SubCmd_RequestDeviceInfo,
@@ -301,13 +303,13 @@ namespace ams::controller {
                 ._unk2 = 0x02
             }
         };
-        
+
         return this->FakeSubCmdResponse(&response);
     }
 
     Result EmulatedSwitchController::SubCmdSpiFlashRead(const bluetooth::HidReport *report) {
         // These are read from official Pro Controller
-        // @ 0x00006000: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff                            <= Serial 
+        // @ 0x00006000: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff                            <= Serial
         // @ 0x00006050: 32 32 32 ff ff ff ff ff ff ff ff ff                                        <= RGB colours (body, buttons, left grip, right grip)
         // @ 0x00006080: 50 fd 00 00 c6 0f 0f 30 61 ae 90 d9 d4 14 54 41 15 54 c7 79 9c 33 36 63    <= Factory Sensor and Stick device parameters
         // @ 0x00006098: 0f 30 61 ae 90 d9 d4 14 54 41 15 54 c7 79 9c 33 36 63                      <= Stick device parameters 2. Normally the same with 1, even in Pro Contr.
@@ -366,6 +368,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdSetInputReportMode(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x80,
             .id = SubCmd_SetInputReportMode
@@ -374,7 +378,9 @@ namespace ams::controller {
         return this->FakeSubCmdResponse(&response);
     }
 
-    Result EmulatedSwitchController::SubCmdTriggersElapsedTime(const bluetooth::HidReport *report) {       
+    Result EmulatedSwitchController::SubCmdTriggersElapsedTime(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x83,
             .id = SubCmd_TriggersElapsedTime
@@ -384,6 +390,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdSetShipPowerState(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x80,
             .id = SubCmd_SetShipPowerState,
@@ -396,6 +404,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdSetMcuConfig(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0xa0,
             .id = SubCmd_SetMcuConfig,
@@ -410,6 +420,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdSetMcuState(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x80,
             .id = SubCmd_SetMcuState
@@ -432,6 +444,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdSetHomeLed(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x80,
             .id = SubCmd_SetHomeLed
@@ -441,6 +455,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdEnableImu(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x80,
             .id = SubCmd_EnableImu
@@ -450,6 +466,8 @@ namespace ams::controller {
     }
 
     Result EmulatedSwitchController::SubCmdEnableVibration(const bluetooth::HidReport *report) {
+        AMS_UNUSED(report);
+
         const SwitchSubcommandResponse response = {
             .ack = 0x80,
             .id = SubCmd_EnableVibration

--- a/mc_mitm/source/controllers/emulated_switch_controller.hpp
+++ b/mc_mitm/source/controllers/emulated_switch_controller.hpp
@@ -30,16 +30,16 @@ namespace ams::controller {
 
             virtual Result Initialize(void);
             bool IsOfficialController(void) { return false; }
-            
+
             Result HandleIncomingReport(const bluetooth::HidReport *report);
             Result HandleOutgoingReport(const bluetooth::HidReport *report);
 
         protected:
             void ClearControllerState(void);
-            virtual void UpdateControllerState(const bluetooth::HidReport *report) { }
-            virtual Result SetVibration(const SwitchRumbleData *rumble_data) { return ams::ResultSuccess(); }
+            virtual void UpdateControllerState(const bluetooth::HidReport *report) { AMS_UNUSED(report); }
+            virtual Result SetVibration(const SwitchRumbleData *rumble_data) { AMS_UNUSED(rumble_data); return ams::ResultSuccess(); }
             virtual Result CancelVibration(void) { return ams::ResultSuccess(); }
-            virtual Result SetPlayerLed(uint8_t led_mask) { return ams::ResultSuccess(); }
+            virtual Result SetPlayerLed(uint8_t led_mask) { AMS_UNUSED(led_mask); return ams::ResultSuccess(); }
 
             Result HandleSubCmdReport(const bluetooth::HidReport *report);
             Result HandleRumbleReport(const bluetooth::HidReport *report);

--- a/mc_mitm/source/controllers/nvidia_shield_controller.cpp
+++ b/mc_mitm/source/controllers/nvidia_shield_controller.cpp
@@ -19,7 +19,7 @@
 namespace ams::controller {
 
     namespace {
-        
+
         constexpr float stick_scale_factor = float(UINT12_MAX) / UINT16_MAX;
 
     }
@@ -76,13 +76,13 @@ namespace ams::controller {
         m_buttons.plus  = src->input0x01.buttons.start;
 
         m_buttons.lstick_press = src->input0x01.buttons.L3;
-        m_buttons.rstick_press = src->input0x01.buttons.R3;    
+        m_buttons.rstick_press = src->input0x01.buttons.R3;
 
         m_buttons.home = src->input0x01.home;
     }
 
     void NvidiaShieldController::HandleInputReport0x03(const NvidiaShieldReportData *src) {
-
+        AMS_UNUSED(src);
     }
 
 }

--- a/mc_mitm/source/controllers/wii_controller.cpp
+++ b/mc_mitm/source/controllers/wii_controller.cpp
@@ -131,7 +131,7 @@ namespace ams::controller {
     }
 
     void WiiController::HandleInputReport0x22(const WiiReportData *src) {
-        ;
+        AMS_UNUSED(src);
     }
 
     void WiiController::HandleInputReport0x30(const WiiReportData *src) {

--- a/mc_mitm/source/mcmitm_initialization.cpp
+++ b/mc_mitm/source/mcmitm_initialization.cpp
@@ -24,7 +24,7 @@
 #include "bluetooth_mitm/bluetooth/bluetooth_core.hpp"
 #include "bluetooth_mitm/bluetooth/bluetooth_hid.hpp"
 #include "bluetooth_mitm/bluetooth/bluetooth_ble.hpp"
- 
+
 namespace ams::mitm {
 
     namespace {
@@ -36,7 +36,7 @@ namespace ams::mitm {
 
         os::Event g_init_event(os::EventClearMode_ManualClear);
 
-        void InitializeThreadFunc(void *arg) {
+        void InitializeThreadFunc(void *) {
             // Start bluetooth event handling thread
             ams::bluetooth::events::Initialize();
 
@@ -84,15 +84,15 @@ namespace ams::mitm {
     }
 
     void StartInitialize(void) {
-        R_ABORT_UNLESS(os::CreateThread(&g_initialize_thread, 
-            InitializeThreadFunc, 
-            nullptr, 
-            g_initialize_thread_stack, 
-            sizeof(g_initialize_thread_stack), 
+        R_ABORT_UNLESS(os::CreateThread(&g_initialize_thread,
+            InitializeThreadFunc,
+            nullptr,
+            g_initialize_thread_stack,
+            sizeof(g_initialize_thread_stack),
             -7
         ));
 
-        os::StartThread(&g_initialize_thread);  
+        os::StartThread(&g_initialize_thread);
     }
 
     void WaitInitialized(void) {


### PR DESCRIPTION
Feel free to use these changes (or not), but this makes the appropriate changes to be buildable using latest atmosphere-libs, which has "a lot" of breaking changes.

Also, fixes what looks like a bug in HandlePinCodeRequest*, adds lmem heap (newlib heap is now completely unsupported by ams), fixes a bug that would cause ipc mis-serialization for types you improperly tagged with sf::LargeData.

btw, looks like you're using a custom shared memory type -- consider using ams::os::SharedMemory(Type), which exists now.
