### PR TITLE
Enable subcmd rumble only when not disabled globally

### DIFF
--- a/mc_mitm/source/controllers/emulated_switch_controller.cpp
+++ b/mc_mitm/source/controllers/emulated_switch_controller.cpp
@@ -559,7 +559,7 @@ namespace ams::controller {
     Result EmulatedSwitchController::SubCmdEnableVibration(const bluetooth::HidReport *report) {
         auto switch_report = reinterpret_cast<const SwitchReportData *>(&report->data);
 
-        m_enable_rumble = mitm::GetGlobalConfig()->general.enable_rumble | switch_report->output0x01.subcmd.set_vibration.enabled;
+        m_enable_rumble = mitm::GetGlobalConfig()->general.enable_rumble & switch_report->output0x01.subcmd.set_vibration.enabled;
 
         const SwitchSubcommandResponse response = {
             .ack = 0x80,


### PR DESCRIPTION
This should fix the recent reports of users incapable of disabling rumble.