### PR TITLE
More cross-platform mcmitm_version.cpp target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,16 @@ GIT_BRANCH := $(shell git symbolic-ref --short HEAD | sed s/[^a-zA-Z0-9_-]/_/g)
 GIT_HASH := $(shell git rev-parse --short HEAD)
 GIT_TAG := $(shell git describe --tags `git rev-list --tags --max-count=1`)
 
-VERSION := $(shell [[ $(GIT_TAG) =~ ^v([0-9]+).([0-9]+).([0-9]+) ]] && printf '0x%02X%02X%02X' $${BASH_REMATCH[1]} $${BASH_REMATCH[2]} $${BASH_REMATCH[3]})
+VERSION := $(shell printf "0x%02X%02X%02X" $(shell echo "$(GIT_TAG)" | sed -E 's/^v([0-9]+).([0-9]+).([0-9]+)/\1 \2 \3/g'))
 BUILD_VERSION := $(GIT_TAG:v%=%)-$(GIT_BRANCH)-$(GIT_HASH)
+BUILD_DATE := $(shell date)
 
 TARGETS := mcmitm_version.cpp mc_mitm
 
 all: $(TARGETS)
 
 mcmitm_version.cpp: .git/HEAD .git/index
-	echo "namespace ams::mitm { unsigned int mc_version = $(VERSION); const char *mc_build_name = \"$(BUILD_VERSION)\"; const char *mc_build_date = \"$$(date)\"; }" > mc_mitm/source/$@
+	echo "namespace ams::mitm { unsigned int mc_version = $(VERSION); const char *mc_build_name = \"$(BUILD_VERSION)\"; const char *mc_build_date = \"$(BUILD_DATE)\"; }" > mc_mitm/source/$@
 
 mc_mitm:
 	$(MAKE) -C $@


### PR DESCRIPTION
This is an attempt to address the issue reported in #518 by making the shell commands used by the `mcmitm_version.cpp` target more cross-platform (or, at least, "cross-shell").

Tested successfully on:
- msys2
- bash
- sh
- dash
- zsh