### PR TITLE
Added support for Arcade Control Panel for AtGames Legends Pinball Controller

### DIFF
--- a/mc_mitm/source/controllers/atgames_controller.cpp
+++ b/mc_mitm/source/controllers/atgames_controller.cpp
@@ -101,9 +101,9 @@ namespace ams::controller {
             m_buttons.X = src->input0x01.x_button;
             m_buttons.Y = src->input0x01.y_button;
 
-            m_buttons.R  = src->input0x01.z_button;
+            m_buttons.R  = src->input0x01.c_button;
             m_buttons.ZR = src->input0x01.flipper_right;
-            m_buttons.L  = src->input0x01.c_button;
+            m_buttons.L  = src->input0x01.z_button;
             m_buttons.ZL = src->input0x01.flipper_left; 
 
             m_buttons.minus = src->input0x01.rewind;

--- a/mc_mitm/source/controllers/atgames_controller.cpp
+++ b/mc_mitm/source/controllers/atgames_controller.cpp
@@ -38,7 +38,7 @@ namespace ams::controller {
     void AtGamesController::MapInputReport0x01(const AtGamesReportData *src) {
         if (!m_arcadepanel) {
             // Checking if any of the optional Arcade Control Panel buttons are pressed and and switching the mapping
-            if (src->input0x01.a_button || src->input0x01.b_button || src->input0x01.c_button || src->input0x01.x_button || src->input0x01.y_button || src->input0x01.z_button)
+            if (src->input0x01.a_button || src->input0x01.b_button || src->input0x01.c_button || src->input0x01.x_button || src->input0x01.y_button || src->input0x01.z_button) {
                 m_arcadepanel = true;
             }
             m_left_stick.SetData(

--- a/mc_mitm/source/controllers/atgames_controller.cpp
+++ b/mc_mitm/source/controllers/atgames_controller.cpp
@@ -36,38 +36,81 @@ namespace ams::controller {
     }
 
     void AtGamesController::MapInputReport0x01(const AtGamesReportData *src) {
-        m_left_stick.SetData(
-            STICK_ZERO + 0x7ff * (src->input0x01.nudge_left - src->input0x01.nudge_right),
-            STICK_ZERO
-        );
-        m_right_stick.SetData(
-            STICK_ZERO,
-            static_cast<uint16_t>(stick_scale_factor * (UINT8_MAX - src->input0x01.right_stick.x)) & 0xfff
-        );
-        
-        m_buttons.dpad_down   = (src->input0x01.dpad == AtGamesDPad_S)  ||
-                                (src->input0x01.dpad == AtGamesDPad_SE) ||
-                                (src->input0x01.dpad == AtGamesDPad_SW);
-        m_buttons.dpad_up     = (src->input0x01.dpad == AtGamesDPad_N)  ||
-                                (src->input0x01.dpad == AtGamesDPad_NE) ||
-                                (src->input0x01.dpad == AtGamesDPad_NW);
-        m_buttons.dpad_right  = (src->input0x01.dpad == AtGamesDPad_E)  ||
-                                (src->input0x01.dpad == AtGamesDPad_NE) ||
-                                (src->input0x01.dpad == AtGamesDPad_SE);
-        m_buttons.dpad_left   = (src->input0x01.dpad == AtGamesDPad_W)  ||
-                                (src->input0x01.dpad == AtGamesDPad_NW) ||
-                                (src->input0x01.dpad == AtGamesDPad_SW);
+        if (!m_arcadepanel) {
+            // Checking if any of the optional Arcade Control Panel buttons are pressed and and switching the mapping
+            if (src->input0x01.a_button || src->input0x01.b_button || src->input0x01.c_button || src->input0x01.x_button || src->input0x01.y_button || src->input0x01.z_button)
+                m_arcadepanel = true;
+            }
+            m_left_stick.SetData(
+                STICK_ZERO + 0x7ff * (src->input0x01.nudge_left - src->input0x01.nudge_right),
+                STICK_ZERO
+            );
+            m_right_stick.SetData(
+                STICK_ZERO,
+                static_cast<uint16_t>(stick_scale_factor * (UINT8_MAX - src->input0x01.right_stick.x)) & 0xfff
+            );
+            
+            m_buttons.dpad_down   = (src->input0x01.dpad == AtGamesDPad_S)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_SE) ||
+                                    (src->input0x01.dpad == AtGamesDPad_SW);
+            m_buttons.dpad_up     = (src->input0x01.dpad == AtGamesDPad_N)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_NE) ||
+                                    (src->input0x01.dpad == AtGamesDPad_NW);
+            m_buttons.dpad_right  = (src->input0x01.dpad == AtGamesDPad_E)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_NE) ||
+                                    (src->input0x01.dpad == AtGamesDPad_SE);
+            m_buttons.dpad_left   = (src->input0x01.dpad == AtGamesDPad_W)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_NW) ||
+                                    (src->input0x01.dpad == AtGamesDPad_SW);
 
-        m_buttons.A = src->input0x01.play;
-        m_buttons.B = src->input0x01.rewind;
-        m_buttons.Y = src->input0x01.nudge_front;
+            m_buttons.A = src->input0x01.play;
+            m_buttons.B = src->input0x01.rewind;
+            m_buttons.Y = src->input0x01.nudge_front;
 
-        m_buttons.R  = src->input0x01.flipper_right;
-        m_buttons.ZR = src->input0x01.flipper_right;
-        m_buttons.L  = src->input0x01.flipper_left;
-        m_buttons.ZL = src->input0x01.flipper_left; 
+            m_buttons.R  = src->input0x01.flipper_right;
+            m_buttons.ZR = src->input0x01.flipper_right;
+            m_buttons.L  = src->input0x01.flipper_left;
+            m_buttons.ZL = src->input0x01.flipper_left; 
 
-        m_buttons.plus  = src->input0x01.home_twirl;
+            m_buttons.plus  = src->input0x01.home_twirl;
+        } else {
+            m_left_stick.SetData(
+                STICK_ZERO + 0x7ff * (src->input0x01.nudge_left - src->input0x01.nudge_right),
+                STICK_ZERO + 0x7ff * (src->input0x01.nudge_front)
+            );
+            m_right_stick.SetData(
+                STICK_ZERO,
+                static_cast<uint16_t>(stick_scale_factor * (UINT8_MAX - src->input0x01.right_stick.x)) & 0xfff
+            );
+            
+            m_buttons.dpad_down   = (src->input0x01.dpad == AtGamesDPad_S)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_SE) ||
+                                    (src->input0x01.dpad == AtGamesDPad_SW);
+            m_buttons.dpad_up     = (src->input0x01.dpad == AtGamesDPad_N)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_NE) ||
+                                    (src->input0x01.dpad == AtGamesDPad_NW);
+            m_buttons.dpad_right  = (src->input0x01.dpad == AtGamesDPad_E)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_NE) ||
+                                    (src->input0x01.dpad == AtGamesDPad_SE);
+            m_buttons.dpad_left   = (src->input0x01.dpad == AtGamesDPad_W)  ||
+                                    (src->input0x01.dpad == AtGamesDPad_NW) ||
+                                    (src->input0x01.dpad == AtGamesDPad_SW);
+
+            m_buttons.A = src->input0x01.a_button;
+            m_buttons.B = src->input0x01.b_button;
+            m_buttons.X = src->input0x01.x_button;
+            m_buttons.Y = src->input0x01.y_button;
+
+            m_buttons.R  = src->input0x01.z_button;
+            m_buttons.ZR = src->input0x01.flipper_right;
+            m_buttons.L  = src->input0x01.c_button;
+            m_buttons.ZL = src->input0x01.flipper_left; 
+
+            m_buttons.minus = src->input0x01.rewind;
+            m_buttons.plus  = src->input0x01.play;
+
+            m_buttons.home = src->input0x01.home_twirl;
+        }
     }
 
 }

--- a/mc_mitm/source/controllers/atgames_controller.hpp
+++ b/mc_mitm/source/controllers/atgames_controller.hpp
@@ -76,13 +76,14 @@ namespace ams::controller {
             };
 
             AtGamesController(const bluetooth::Address *address, HardwareID id)
-            : EmulatedSwitchController(address, id) { }
+            : EmulatedSwitchController(address, id), m_arcadepanel(false) { }
 
             void ProcessInputData(const bluetooth::HidReport *report) override;
 
         private:
             void MapInputReport0x01(const AtGamesReportData *src);
-            bool m_arcadepanel = false;
+        
+            bool m_arcadepanel;
 
     };
 

--- a/mc_mitm/source/controllers/atgames_controller.hpp
+++ b/mc_mitm/source/controllers/atgames_controller.hpp
@@ -38,16 +38,19 @@ namespace ams::controller {
     struct AtGamesInputReport0x01 {
         uint8_t rewind          : 1;
         uint8_t nudge_front     : 1;
-        uint8_t                 : 2;
+        uint8_t b_button        : 1;
+        uint8_t y_button        : 1;
         uint8_t nudge_left      : 1;
         uint8_t flipper_right   : 1;
-        uint8_t                 : 1;
+        uint8_t x_button        : 1;
         uint8_t play            : 1;
 
-        uint8_t                 : 1;
+        uint8_t a_button        : 1;
         uint8_t home_twirl      : 1;
         uint8_t flipper_left    : 1;
         uint8_t nudge_right     : 1;
+        uint8_t z_button        : 1;
+        uint8_t c_button        : 1;
         uint8_t                 : 0;
 
         uint8_t unk1[2];
@@ -79,6 +82,7 @@ namespace ams::controller {
 
         private:
             void MapInputReport0x01(const AtGamesReportData *src);
+            bool m_arcadepanel = false;
 
     };
 


### PR DESCRIPTION
Addresses issue #558 

- Added support for the Arcade Control Panel
- If ABCXYZ button on control panel is pressed it will switch to enhanced control panel mappings 

Enhanced control panel mappings are as so:
![IMG-8460](https://user-images.githubusercontent.com/6358878/211054888-f9c8956f-91d4-489c-87d1-ffe20befa367.jpg)
![IMG-8461](https://user-images.githubusercontent.com/6358878/210615668-5570fc68-03e4-48e5-8709-5fb8f14dded0.jpg)
![IMG-8462](https://user-images.githubusercontent.com/6358878/210847614-3f9fb221-256a-4af2-beb7-8bc850226c7c.jpg)



These mappings have been verified to work on all major pinball titles for the Switch
