### PR TITLE
Add configurable analog-trigger → stick mapping (closes #1006)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ dist: all
 
 	mkdir -p dist/config/MissionControl
 	mkdir -p dist/config/MissionControl/controllers
+	mkdir -p dist/config/MissionControl/titles
 	cp mc_mitm/config.ini dist/config/MissionControl/missioncontrol.ini.template
 
 	cd dist; zip -r $(PROJECT_NAME)-$(BUILD_VERSION).zip ./*; cd ../;

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use controllers from other consoles natively on your Nintendo Switch via Bluetoo
 * Enables use of [JoyConDroid](https://github.com/TeamJCD/JoyConDroid) without root access.
 * Spoofing of host Bluetooth adapter name and address.
 * `mc.mitm` module adds extension IPC commands that can be used to interact with the `bluetooth` process without interfering with the state of the system.
+* Configurable mapping of analog triggers onto the right-stick Y axis, with per-game and per-controller overrides — useful for games that read throttle/brake from the stick rather than ZR/ZL (e.g. Grid Autosport).
 
 ### Supported Controllers
 
@@ -156,6 +157,16 @@ These are miscellaneous controller-specific settings etc.
     - `dualsense_lightbar_brightness` Set LED lightbar brightness for Sony Dualsense controllers. Valid range [0-9] where 0=off, 1=min, 2-9=12.5-100% in 12.5% increments.
     - `dualsense_enable_player_leds` Enable/disable the white player indicator LEDs below the Dualsense touchpad.
     - `dualsense_vibration_intensity` Set Dualsense vibration intensity, 12.5% per increment. Valid range [1-8] where 1=12.5%, 8=100%.
+
+- `[trigger_map]`
+Configurable mapping of analog triggers onto stick axes, for games that read throttle/brake from the right-stick Y rather than ZR/ZL. Default `mode=off` is a no-op; per-controller subclasses individually opt into the feature.
+    - `mode` Active mapping. Valid values: `off`, `rstick_y_split` (RT → +Y, LT → -Y on right stick).
+    - `zr_threshold` / `zl_threshold` Trigger-percent threshold above which the digital ZR/ZL bit fires while a mapping is active. Range [0-100] or `off` (default — usually you want the trigger to be analog-only in this mode).
+    - `stick_y_to_buttons_threshold` In `rstick_y_split`, fires ZR (up) / ZL (down) when the physical stick Y is deflected past N%. Range [0-100] or `off` (default).
+    - `deadzone` Deadzone on the raw trigger before activation. Range [0-100].
+    - `invert_y` Flip trigger-to-stick direction (RT → -Y, LT → +Y).
+
+These settings form the global default. Per-game overrides go in `/config/MissionControl/titles/<16-hex-program-id>.ini` (e.g. `0100dc800a602000.ini`); per-controller overrides in `/config/MissionControl/controllers/<lowercase-MAC>.ini`. Each override file is parsed as a complete `[trigger_map]` profile (fields are not merged with the global). Precedence: per-title > per-controller > global. Override directories are re-scanned on every title switch — adding a game profile takes effect on next launch without a sysmodule restart.
 
 ### Removal
 

--- a/mc_mitm/config.ini
+++ b/mc_mitm/config.ini
@@ -28,3 +28,24 @@
 ;dualsense_enable_player_leds=false
 ; Set Dualsense vibration intensity, 12.5% per increment. Valid range [1-8] where 1=12.5%, 8=100% [default 4(50%)]
 ;dualsense_vibration_intensity=4
+
+[trigger_map]
+; Configurable analog-trigger-to-stick remapping. Lets games like Grid Autosport
+; or Mario Sunshine use bluetooth-controller analog triggers as throttle/brake/etc
+; via the right-stick analog axis they already support.
+; mode: off | rstick_y_split  (RT -> +Y, LT -> -Y on right stick) [default off]
+;mode=off
+; Threshold (0-100) on normalized RT before ZR also fires digitally. In modes
+; that map a trigger to an analog stick axis the digital ZR is usually unwanted
+; (e.g. Grid Autosport / Mario Sunshine read the analog axis, not ZR), so this
+; defaults to "off". Set 0-100 to opt in (e.g. =95 makes a near-full RT pull
+; act as a boost button). [default off]
+;zr_threshold=off
+; Threshold (0-100) on normalized LT before ZL also fires digitally, or "off"
+; to disable. [default off]
+;zl_threshold=off
+; Deadzone (0-100) on the raw trigger before activation [default 0]
+;deadzone=0
+; Invert Y-axis direction (RT -> -Y, LT -> +Y) for games that expect the opposite
+; convention [default false]
+;invert_y=false

--- a/mc_mitm/config.ini
+++ b/mc_mitm/config.ini
@@ -53,6 +53,13 @@
 ; Threshold (0-100) on normalized LT before ZL also fires digitally, or "off"
 ; to disable. [default off]
 ;zl_threshold=off
+; In rstick_y_split mode the right-stick Y axis is overwritten by the trigger
+; values, so physical up/down on the stick is otherwise wasted. Setting this to
+; a 0-100 stick-deflection percentage repurposes that motion: physically pushing
+; the right stick up past N% fires ZR, pushing it down past N% fires ZL. Useful
+; e.g. for racing games where you want gear shifts on the same thumb that's on
+; the throttle stick. "off" disables. [default off]
+;stick_y_to_buttons_threshold=off
 ; Deadzone (0-100) on the raw trigger before activation [default 0]
 ;deadzone=0
 ; Invert Y-axis direction (RT -> -Y, LT -> +Y) for games that expect the opposite

--- a/mc_mitm/config.ini
+++ b/mc_mitm/config.ini
@@ -33,6 +33,15 @@
 ; Configurable analog-trigger-to-stick remapping. Lets games like Grid Autosport
 ; or Mario Sunshine use bluetooth-controller analog triggers as throttle/brake/etc
 ; via the right-stick analog axis they already support.
+;
+; Per-controller and per-title overrides are also supported. Drop a [trigger_map]
+; section into:
+;   sdmc:/config/MissionControl/controllers/<lowercase-mac-no-separators>.ini
+;   sdmc:/config/MissionControl/titles/<16-hex-program-id>.ini
+; Precedence is per-title > per-controller > the [trigger_map] block in this file
+; (whichever level matches first wins as a complete profile -- fields are not
+; merged across levels).
+;
 ; mode: off | rstick_y_split  (RT -> +Y, LT -> -Y on right stick) [default off]
 ;mode=off
 ; Threshold (0-100) on normalized RT before ZR also fires digitally. In modes

--- a/mc_mitm/source/controllers/dualshock4_controller.cpp
+++ b/mc_mitm/source/controllers/dualshock4_controller.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "dualshock4_controller.hpp"
+#include "trigger_mapper.hpp"
 #include "../mcmitm_config.hpp"
 #include <switch.h>
 #include <stratosphere.hpp>
@@ -51,6 +52,7 @@ namespace ams::controller {
         auto config = mitm::GetGlobalConfig();
         m_report_rate = static_cast<Dualshock4ReportRate>(config->misc.dualshock4_polling_rate);
         m_lightbar_brightness = config->misc.dualshock4_lightbar_brightness;
+        m_supports_trigger_map = true;
 
         R_TRY(this->PushRumbleLedState());
         R_TRY(EmulatedSwitchController::Initialize());
@@ -116,6 +118,9 @@ namespace ams::controller {
 
         m_buttons.ZR = src->input0x01.right_trigger > (m_trigger_threshold * TriggerMax);
         m_buttons.ZL = src->input0x01.left_trigger  > (m_trigger_threshold * TriggerMax);
+
+        m_left_trigger_raw  = NormalizeTriggerU8(src->input0x01.left_trigger);
+        m_right_trigger_raw = NormalizeTriggerU8(src->input0x01.right_trigger);
     }
 
     void Dualshock4Controller::MapInputReport0x11(const Dualshock4ReportData *src) {
@@ -144,6 +149,9 @@ namespace ams::controller {
 
         m_buttons.ZR = src->input0x11.right_trigger > (m_trigger_threshold * TriggerMax);
         m_buttons.ZL = src->input0x11.left_trigger  > (m_trigger_threshold * TriggerMax);
+
+        m_left_trigger_raw  = NormalizeTriggerU8(src->input0x11.left_trigger);
+        m_right_trigger_raw = NormalizeTriggerU8(src->input0x11.right_trigger);
 
         if (src->input0x11.buttons.touchpad) {
             for (int i = 0; i < src->input0x11.num_reports; ++i) {

--- a/mc_mitm/source/controllers/emulated_switch_controller.cpp
+++ b/mc_mitm/source/controllers/emulated_switch_controller.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "emulated_switch_controller.hpp"
+#include "trigger_mapper.hpp"
 #include "../utils.hpp"
 #include "../mcmitm_config.hpp"
 
@@ -60,6 +61,8 @@ namespace ams::controller {
         std::memset(&m_buttons, 0, sizeof(m_buttons));
         m_left_stick.SetData(SwitchAnalogStick::Center, SwitchAnalogStick::Center);
         m_right_stick.SetData(SwitchAnalogStick::Center, SwitchAnalogStick::Center);
+        m_left_trigger_raw = 0;
+        m_right_trigger_raw = 0;
         std::memset(&m_accel, 0, sizeof(m_accel));
         std::memset(&m_gyro, 0, sizeof(m_gyro));
         m_motion_packer->SetGyroSensitivity(GyroSensitivity_2000Dps);
@@ -68,6 +71,11 @@ namespace ams::controller {
 
     void EmulatedSwitchController::UpdateControllerState(const bluetooth::HidReport *report) {
         this->ProcessInputData(report);
+
+        if (m_supports_trigger_map) {
+            TriggerMapper::Instance().Apply(m_buttons, m_left_stick, m_right_stick,
+                                            m_left_trigger_raw, m_right_trigger_raw);
+        }
 
         auto input_report = reinterpret_cast<SwitchInputReport *>(m_input_report.data);
         input_report->id = m_input_report_mode;

--- a/mc_mitm/source/controllers/emulated_switch_controller.cpp
+++ b/mc_mitm/source/controllers/emulated_switch_controller.cpp
@@ -73,7 +73,8 @@ namespace ams::controller {
         this->ProcessInputData(report);
 
         if (m_supports_trigger_map) {
-            TriggerMapper::Instance().Apply(m_buttons, m_left_stick, m_right_stick,
+            TriggerMapper::Instance().Apply(m_address,
+                                            m_buttons, m_left_stick, m_right_stick,
                                             m_left_trigger_raw, m_right_trigger_raw);
         }
 

--- a/mc_mitm/source/controllers/emulated_switch_controller.hpp
+++ b/mc_mitm/source/controllers/emulated_switch_controller.hpp
@@ -78,6 +78,15 @@ namespace ams::controller {
             SwitchButtonData m_buttons;
             SwitchAnalogStick m_left_stick;
             SwitchAnalogStick m_right_stick;
+            // Raw analog trigger values normalized to u16 (0..0xFFFF), populated by
+            // per-controller subclasses that opt into the trigger-mapper post-hook.
+            u16 m_left_trigger_raw  = 0;
+            u16 m_right_trigger_raw = 0;
+            // Subclass sets this to true to participate in the trigger→stick mapper.
+            // Stays false for controllers without analog triggers, which would
+            // otherwise have their right-stick Y pinned to center when a mapping
+            // mode is active globally.
+            bool m_supports_trigger_map = false;
             Vec3d<float> m_accel;
             Vec3d<float> m_gyro;
 

--- a/mc_mitm/source/controllers/trigger_mapper.cpp
+++ b/mc_mitm/source/controllers/trigger_mapper.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020-2026 ndeadly
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "trigger_mapper.hpp"
+#include "switch_analog_stick.hpp"
+#include <algorithm>
+
+namespace ams::controller {
+
+    namespace {
+
+        // Normalize raw 0..0xFFFF trigger into 0..1 after deadzone is applied.
+        // Returns 0 when raw <= deadzone_floor; otherwise rescales the remaining
+        // travel back to 0..1 so the deadzone doesn't compress the active range.
+        float NormalizeWithDeadzone(u16 raw, u8 deadzone_pct) {
+            const float v       = raw / static_cast<float>(0xFFFF);
+            const float dz      = std::min(deadzone_pct, u8(99)) / 100.0f;
+            if (v <= dz) {
+                return 0.0f;
+            }
+            return (v - dz) / (1.0f - dz);
+        }
+
+        u16 DeflectionToY12Bit(float deflection /* in [-1, +1] */) {
+            constexpr int Center   = SwitchAnalogStick::Center;             // 0x800
+            constexpr int HalfSpan = SwitchAnalogStick::Max - Center;       // 0x7FF
+            const int y = Center + static_cast<int>(deflection * HalfSpan);
+            return static_cast<u16>(std::clamp(y, int(SwitchAnalogStick::Min), int(SwitchAnalogStick::Max)));
+        }
+
+        constinit TriggerMapper g_mapper;
+
+    }
+
+    TriggerMapper& TriggerMapper::Instance() {
+        return g_mapper;
+    }
+
+    void TriggerMapper::Initialize(const TriggerProfile& global_profile) {
+        m_global = global_profile;
+    }
+
+    void TriggerMapper::Apply(SwitchButtonData& buttons,
+                              SwitchAnalogStick& /* lstick */,
+                              SwitchAnalogStick& rstick,
+                              u16 left_trigger_norm,
+                              u16 right_trigger_norm) {
+        const TriggerProfile& p = m_global;
+        if (p.mode == TriggerMode::Off) {
+            return;
+        }
+
+        const float lt = NormalizeWithDeadzone(left_trigger_norm,  p.deadzone);
+        const float rt = NormalizeWithDeadzone(right_trigger_norm, p.deadzone);
+
+        switch (p.mode) {
+            case TriggerMode::RstickYSplit: {
+                float deflection = rt - lt;                                  // [-1, +1]
+                if (p.invert_y) {
+                    deflection = -deflection;
+                }
+                rstick.SetY(DeflectionToY12Bit(deflection));
+
+                // Override ZL/ZR — only fire after the configured threshold of trigger travel.
+                buttons.ZR = (rt * 100.0f) >= p.zr_threshold ? 1 : 0;
+                buttons.ZL = (lt * 100.0f) >= p.zl_threshold ? 1 : 0;
+                break;
+            }
+            case TriggerMode::Off:
+            default:
+                break;
+        }
+    }
+
+}

--- a/mc_mitm/source/controllers/trigger_mapper.cpp
+++ b/mc_mitm/source/controllers/trigger_mapper.cpp
@@ -156,6 +156,24 @@ namespace ams::controller {
 
         constinit TriggerMapper g_mapper;
 
+        // Background thread that watches the existing process-switch event and
+        // re-runs LoadDirectoryProfiles on each title transition. Runs entirely
+        // off the bluetooth input path — fs::OpenDirectory / fs::ReadDirectory
+        // happen here, never inside TriggerMapper::Apply.
+        constexpr s32    HotReloadThreadPriority  = 21;
+        constexpr size_t HotReloadThreadStackSize = 0x4000;
+        alignas(os::ThreadStackAlignment) constinit u8 g_hot_reload_stack[HotReloadThreadStackSize];
+        constinit os::ThreadType g_hot_reload_thread;
+        constinit bool           g_hot_reload_started = false;
+
+        void HotReloadThreadFn(void *) {
+            os::Event *event = mc::GetProcessSwitchEvent();
+            for (;;) {
+                event->Wait();
+                TriggerMapper::Instance().LoadDirectoryProfiles();
+            }
+        }
+
     }
 
     TriggerMapper& TriggerMapper::Instance() {
@@ -163,10 +181,19 @@ namespace ams::controller {
     }
 
     void TriggerMapper::Initialize(const TriggerProfile& global_profile) {
+        std::scoped_lock lk(m_mutex);
         m_global = global_profile;
     }
 
     void TriggerMapper::LoadDirectoryProfiles() {
+        std::scoped_lock lk(m_mutex);
+        this->LoadDirectoryProfilesUnsafe();
+    }
+
+    void TriggerMapper::LoadDirectoryProfilesUnsafe() {
+        m_controllers.clear();
+        m_titles.clear();
+
         ForEachIniFile(ControllersDir, 12 /* hex chars in a MAC */,
             [this](const char *stem, const char *full_path) {
                 bluetooth::Address addr;
@@ -186,8 +213,24 @@ namespace ams::controller {
             });
     }
 
-    const TriggerProfile& TriggerMapper::Resolve(const bluetooth::Address& addr) const {
-        const u64 current_title = mc::GetCurrentProgramId().value;
+    void TriggerMapper::StartHotReloadThread() {
+        std::scoped_lock lk(m_mutex);
+        if (g_hot_reload_started) {
+            return;
+        }
+        g_hot_reload_started = true;
+        R_ABORT_UNLESS(os::CreateThread(&g_hot_reload_thread,
+            HotReloadThreadFn,
+            nullptr,
+            g_hot_reload_stack,
+            HotReloadThreadStackSize,
+            HotReloadThreadPriority
+        ));
+        os::SetThreadNamePointer(&g_hot_reload_thread, "mc::TriggerMapHotReload");
+        os::StartThread(&g_hot_reload_thread);
+    }
+
+    const TriggerProfile& TriggerMapper::Resolve(const bluetooth::Address& addr, u64 current_title) const {
         if (current_title != 0) {
             for (const auto& t : m_titles) {
                 if (t.title_id == current_title) {
@@ -209,7 +252,9 @@ namespace ams::controller {
                               SwitchAnalogStick& rstick,
                               u16 left_trigger_norm,
                               u16 right_trigger_norm) {
-        const TriggerProfile& p = this->Resolve(addr);
+        std::scoped_lock lk(m_mutex);
+        const u64 current_title = mc::GetCurrentProgramId().value;
+        const TriggerProfile& p = this->Resolve(addr, current_title);
         if (p.mode == TriggerMode::Off) {
             return;
         }

--- a/mc_mitm/source/controllers/trigger_mapper.cpp
+++ b/mc_mitm/source/controllers/trigger_mapper.cpp
@@ -15,18 +15,21 @@
  */
 #include "trigger_mapper.hpp"
 #include "switch_analog_stick.hpp"
+#include "../mcmitm_process_monitor.hpp"
+#include <stratosphere.hpp>
 #include <algorithm>
+#include <cstring>
 
 namespace ams::controller {
 
     namespace {
 
-        // Normalize raw 0..0xFFFF trigger into 0..1 after deadzone is applied.
-        // Returns 0 when raw <= deadzone_floor; otherwise rescales the remaining
-        // travel back to 0..1 so the deadzone doesn't compress the active range.
+        constexpr const char ControllersDir[] = "sdmc:/config/MissionControl/controllers";
+        constexpr const char TitlesDir[]      = "sdmc:/config/MissionControl/titles";
+
         float NormalizeWithDeadzone(u16 raw, u8 deadzone_pct) {
-            const float v       = raw / static_cast<float>(0xFFFF);
-            const float dz      = std::min(deadzone_pct, u8(99)) / 100.0f;
+            const float v  = raw / static_cast<float>(0xFFFF);
+            const float dz = std::min(deadzone_pct, u8(99)) / 100.0f;
             if (v <= dz) {
                 return 0.0f;
             }
@@ -34,10 +37,119 @@ namespace ams::controller {
         }
 
         u16 DeflectionToY12Bit(float deflection /* in [-1, +1] */) {
-            constexpr int Center   = SwitchAnalogStick::Center;             // 0x800
-            constexpr int HalfSpan = SwitchAnalogStick::Max - Center;       // 0x7FF
+            constexpr int Center   = SwitchAnalogStick::Center;
+            constexpr int HalfSpan = SwitchAnalogStick::Max - Center;
             const int y = Center + static_cast<int>(deflection * HalfSpan);
             return static_cast<u16>(std::clamp(y, int(SwitchAnalogStick::Min), int(SwitchAnalogStick::Max)));
+        }
+
+        int ProfileIniHandler(void *user, const char *section, const char *name, const char *value) {
+            if (strcasecmp(section, "trigger_map") != 0) {
+                return 1;  // ignore other sections, don't fail the parse
+            }
+            auto *p = reinterpret_cast<TriggerProfile *>(user);
+
+            auto parse_threshold_or_off = [&](u8 *out) {
+                if (strcasecmp(value, "off") == 0) {
+                    *out = 101;
+                } else {
+                    int tmp = std::strtol(value, nullptr, 10);
+                    if (tmp >= 0 && tmp <= 100) {
+                        *out = static_cast<u8>(tmp);
+                    }
+                }
+            };
+
+            if (strcasecmp(name, "mode") == 0) {
+                if (strcasecmp(value, "off") == 0) {
+                    p->mode = TriggerMode::Off;
+                } else if (strcasecmp(value, "rstick_y_split") == 0) {
+                    p->mode = TriggerMode::RstickYSplit;
+                }
+            } else if (strcasecmp(name, "zr_threshold") == 0) {
+                parse_threshold_or_off(&p->zr_threshold);
+            } else if (strcasecmp(name, "zl_threshold") == 0) {
+                parse_threshold_or_off(&p->zl_threshold);
+            } else if (strcasecmp(name, "deadzone") == 0) {
+                int tmp = std::strtol(value, nullptr, 10);
+                if (tmp >= 0 && tmp <= 100) {
+                    p->deadzone = static_cast<u8>(tmp);
+                }
+            } else if (strcasecmp(name, "invert_y") == 0) {
+                if (strcasecmp(value, "true") == 0)  p->invert_y = true;
+                if (strcasecmp(value, "false") == 0) p->invert_y = false;
+            }
+            return 1;
+        }
+
+        bool ParseProfileFile(const char *path, TriggerProfile *out) {
+            fs::FileHandle file;
+            if (R_FAILED(fs::OpenFile(std::addressof(file), path, fs::OpenMode_Read))) {
+                return false;
+            }
+            ON_SCOPE_EXIT { fs::CloseFile(file); };
+            return R_SUCCEEDED(util::ini::ParseFile(file, out, ProfileIniHandler));
+        }
+
+        // Filename without ".ini" suffix → e.g. "aabbccddeeff" or "0100b00021c70000".
+        // Returns false if the filename doesn't end in .ini or the stem doesn't match
+        // the expected hex length.
+        bool StripIniExtension(const char *name, char *stem_out, size_t stem_capacity, size_t expected_len) {
+            const size_t name_len = std::strlen(name);
+            constexpr size_t suffix_len = 4;  // ".ini"
+            if (name_len < suffix_len + expected_len) return false;
+            if (strcasecmp(name + name_len - suffix_len, ".ini") != 0) return false;
+            const size_t stem_len = name_len - suffix_len;
+            if (stem_len != expected_len) return false;
+            if (stem_len + 1 > stem_capacity) return false;
+            std::memcpy(stem_out, name, stem_len);
+            stem_out[stem_len] = '\0';
+            return true;
+        }
+
+        bool ParseHexMac(const char *stem, bluetooth::Address *out) {
+            // Expected: 12 lowercase hex chars (matches GetControllerDirectory format).
+            char pair[3] = {};
+            for (size_t i = 0; i < sizeof(out->address); ++i) {
+                pair[0] = stem[i*2];
+                pair[1] = stem[i*2 + 1];
+                char *endp = nullptr;
+                unsigned long byte = std::strtoul(pair, &endp, 16);
+                if (endp != pair + 2) return false;
+                out->address[i] = static_cast<u8>(byte);
+            }
+            return true;
+        }
+
+        bool ParseHexU64(const char *stem, u64 *out) {
+            char *endp = nullptr;
+            *out = std::strtoull(stem, &endp, 16);
+            return endp == stem + 16;
+        }
+
+        // Iterate `dir_path` and call `on_each(stem)` for every file matching `*.ini`
+        // with a stem of length `stem_len`. Silently no-ops if the directory can't be
+        // opened.
+        template<typename F>
+        void ForEachIniFile(const char *dir_path, size_t stem_len, F&& on_each) {
+            fs::DirectoryHandle dir;
+            if (R_FAILED(fs::OpenDirectory(std::addressof(dir), dir_path, fs::OpenDirectoryMode_File))) {
+                return;
+            }
+            ON_SCOPE_EXIT { fs::CloseDirectory(dir); };
+
+            // ReadDirectory one-at-a-time so we don't blow the stack on a large entry.
+            fs::DirectoryEntry entry;
+            s64 read_count = 0;
+            while (R_SUCCEEDED(fs::ReadDirectory(&read_count, &entry, dir, 1)) && read_count > 0) {
+                if (entry.type != fs::DirectoryEntryType_File) continue;
+                char stem[64];
+                if (!StripIniExtension(entry.name, stem, sizeof(stem), stem_len)) continue;
+
+                char full_path[fs::EntryNameLengthMax + 64];
+                util::SNPrintf(full_path, sizeof(full_path), "%s/%s", dir_path, entry.name);
+                on_each(stem, full_path);
+            }
         }
 
         constinit TriggerMapper g_mapper;
@@ -52,12 +164,50 @@ namespace ams::controller {
         m_global = global_profile;
     }
 
-    void TriggerMapper::Apply(SwitchButtonData& buttons,
+    void TriggerMapper::LoadDirectoryProfiles() {
+        ForEachIniFile(ControllersDir, 12 /* hex chars in a MAC */,
+            [this](const char *stem, const char *full_path) {
+                bluetooth::Address addr;
+                if (!ParseHexMac(stem, &addr)) return;
+                TriggerProfile profile = m_global;  // start from global, then override
+                if (!ParseProfileFile(full_path, &profile)) return;
+                m_controllers.push_back({addr, profile});
+            });
+
+        ForEachIniFile(TitlesDir, 16 /* hex chars in a Switch programID */,
+            [this](const char *stem, const char *full_path) {
+                u64 title_id;
+                if (!ParseHexU64(stem, &title_id)) return;
+                TriggerProfile profile = m_global;
+                if (!ParseProfileFile(full_path, &profile)) return;
+                m_titles.push_back({title_id, profile});
+            });
+    }
+
+    const TriggerProfile& TriggerMapper::Resolve(const bluetooth::Address& addr) const {
+        const u64 current_title = mc::GetCurrentProgramId().value;
+        if (current_title != 0) {
+            for (const auto& t : m_titles) {
+                if (t.title_id == current_title) {
+                    return t.profile;
+                }
+            }
+        }
+        for (const auto& c : m_controllers) {
+            if (std::memcmp(&c.addr, &addr, sizeof(addr)) == 0) {
+                return c.profile;
+            }
+        }
+        return m_global;
+    }
+
+    void TriggerMapper::Apply(const bluetooth::Address& addr,
+                              SwitchButtonData& buttons,
                               SwitchAnalogStick& /* lstick */,
                               SwitchAnalogStick& rstick,
                               u16 left_trigger_norm,
                               u16 right_trigger_norm) {
-        const TriggerProfile& p = m_global;
+        const TriggerProfile& p = this->Resolve(addr);
         if (p.mode == TriggerMode::Off) {
             return;
         }
@@ -67,13 +217,12 @@ namespace ams::controller {
 
         switch (p.mode) {
             case TriggerMode::RstickYSplit: {
-                float deflection = rt - lt;                                  // [-1, +1]
+                float deflection = rt - lt;
                 if (p.invert_y) {
                     deflection = -deflection;
                 }
                 rstick.SetY(DeflectionToY12Bit(deflection));
 
-                // Override ZL/ZR — only fire after the configured threshold of trigger travel.
                 buttons.ZR = (rt * 100.0f) >= p.zr_threshold ? 1 : 0;
                 buttons.ZL = (lt * 100.0f) >= p.zl_threshold ? 1 : 0;
                 break;

--- a/mc_mitm/source/controllers/trigger_mapper.cpp
+++ b/mc_mitm/source/controllers/trigger_mapper.cpp
@@ -70,6 +70,8 @@ namespace ams::controller {
                 parse_threshold_or_off(&p->zr_threshold);
             } else if (strcasecmp(name, "zl_threshold") == 0) {
                 parse_threshold_or_off(&p->zl_threshold);
+            } else if (strcasecmp(name, "stick_y_to_buttons_threshold") == 0) {
+                parse_threshold_or_off(&p->stick_y_to_buttons_threshold);
             } else if (strcasecmp(name, "deadzone") == 0) {
                 int tmp = std::strtol(value, nullptr, 10);
                 if (tmp >= 0 && tmp <= 100) {
@@ -217,14 +219,29 @@ namespace ams::controller {
 
         switch (p.mode) {
             case TriggerMode::RstickYSplit: {
+                // Capture the physical right-stick Y *before* the trigger-derived
+                // value overwrites it — the user can still meaningfully push the
+                // stick up/down, we just need to grab it now.
+                const u16 physical_y = rstick.GetY();
+
                 float deflection = rt - lt;
                 if (p.invert_y) {
                     deflection = -deflection;
                 }
                 rstick.SetY(DeflectionToY12Bit(deflection));
 
-                buttons.ZR = (rt * 100.0f) >= p.zr_threshold ? 1 : 0;
-                buttons.ZL = (lt * 100.0f) >= p.zl_threshold ? 1 : 0;
+                bool zr = (rt * 100.0f) >= p.zr_threshold;
+                bool zl = (lt * 100.0f) >= p.zl_threshold;
+
+                if (p.stick_y_to_buttons_threshold <= 100) {
+                    const float py_norm = (static_cast<int>(physical_y) - static_cast<int>(SwitchAnalogStick::Center))
+                                        / static_cast<float>(SwitchAnalogStick::Max - SwitchAnalogStick::Center);
+                    if ( py_norm * 100.0f >= p.stick_y_to_buttons_threshold) zr = true;
+                    if (-py_norm * 100.0f >= p.stick_y_to_buttons_threshold) zl = true;
+                }
+
+                buttons.ZR = zr ? 1 : 0;
+                buttons.ZL = zl ? 1 : 0;
                 break;
             }
             case TriggerMode::Off:

--- a/mc_mitm/source/controllers/trigger_mapper.hpp
+++ b/mc_mitm/source/controllers/trigger_mapper.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020-2026 ndeadly
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include "switch_controller.hpp"
+
+namespace ams::controller {
+
+    enum class TriggerMode : u8 {
+        Off            = 0,
+        RstickYSplit   = 1,   // RT → +Y, LT → −Y on the right stick
+    };
+
+    struct TriggerProfile {
+        TriggerMode mode         = TriggerMode::Off;
+        // Trigger-percent threshold above which the digital ZR/ZL bit also fires.
+        // Any value > 100 disables digital firing — appropriate for the racing /
+        // analog-water-pressure use cases where the trigger is now exclusively
+        // an analog stick input.
+        u8          zr_threshold = 101;  // off
+        u8          zl_threshold = 101;  // off
+        u8          deadzone     = 0;    // 0..100, on raw trigger
+        bool        invert_y     = false;
+    };
+
+    // Scale any unsigned-integer trigger value into a normalized 0..0xFFFF range.
+    // Specialised for u8 (DS4/DS3/DualSense — 0xFF * 0x101 = 0xFFFF, exact endpoints).
+    constexpr u16 NormalizeTriggerU8(u8 t) {
+        return static_cast<u16>(t) * 0x101;
+    }
+
+    class TriggerMapper {
+        public:
+            static TriggerMapper& Instance();
+
+            void Initialize(const TriggerProfile& global_profile);
+
+            // Apply the active profile to the per-packet controller state.
+            // No-op when the resolved profile's mode == Off (the hot-path common case).
+            void Apply(SwitchButtonData& buttons,
+                       SwitchAnalogStick& lstick,
+                       SwitchAnalogStick& rstick,
+                       u16 left_trigger_norm,
+                       u16 right_trigger_norm);
+
+        private:
+            TriggerProfile m_global;
+    };
+
+}

--- a/mc_mitm/source/controllers/trigger_mapper.hpp
+++ b/mc_mitm/source/controllers/trigger_mapper.hpp
@@ -34,6 +34,11 @@ namespace ams::controller {
         u8          zl_threshold = 101;  // off
         u8          deadzone     = 0;    // 0..100, on raw trigger
         bool        invert_y     = false;
+        // In rstick_y_split mode the trigger overwrites the right-stick Y axis,
+        // freeing the physical stick's up/down for repurposing as digital ZR/ZL.
+        // 0..100 = stick-deflection percent threshold; > 100 = feature off.
+        // Physical stick up past the threshold fires ZR; down fires ZL.
+        u8          stick_y_to_buttons_threshold = 101;  // off
     };
 
     // Scale any unsigned-integer trigger value into a normalized 0..0xFFFF range.

--- a/mc_mitm/source/controllers/trigger_mapper.hpp
+++ b/mc_mitm/source/controllers/trigger_mapper.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include "switch_controller.hpp"
+#include <vector>
 
 namespace ams::controller {
 
@@ -45,18 +46,38 @@ namespace ams::controller {
         public:
             static TriggerMapper& Instance();
 
+            // Set the global default profile (from the [trigger_map] section of
+            // missioncontrol.ini). Always called once at boot.
             void Initialize(const TriggerProfile& global_profile);
 
-            // Apply the active profile to the per-packet controller state.
-            // No-op when the resolved profile's mode == Off (the hot-path common case).
-            void Apply(SwitchButtonData& buttons,
+            // Scan sdmc:/config/MissionControl/{controllers,titles}/ for per-MAC
+            // and per-titleID overrides. Each filename is expected to be the key
+            // (12-hex MAC for controllers/, 16-hex programID for titles/) with an
+            // .ini extension; each file's [trigger_map] section is parsed into a
+            // complete TriggerProfile. Called once at boot, after Initialize.
+            void LoadDirectoryProfiles();
+
+            // Apply the controller's currently-resolved profile to the per-packet
+            // controller state. No-op when the resolved profile's mode == Off.
+            void Apply(const bluetooth::Address& addr,
+                       SwitchButtonData& buttons,
                        SwitchAnalogStick& lstick,
                        SwitchAnalogStick& rstick,
                        u16 left_trigger_norm,
                        u16 right_trigger_norm);
 
         private:
-            TriggerProfile m_global;
+            // Resolve the active profile for this controller given the currently-running
+            // title. Precedence: per-title > per-controller > global. Profile-level —
+            // whichever level matches first is returned in full, no field merging.
+            const TriggerProfile& Resolve(const bluetooth::Address& addr) const;
+
+            struct ControllerEntry { bluetooth::Address addr;     TriggerProfile profile; };
+            struct TitleEntry      { u64                title_id; TriggerProfile profile; };
+
+            TriggerProfile               m_global;
+            std::vector<ControllerEntry> m_controllers;
+            std::vector<TitleEntry>      m_titles;
     };
 
 }

--- a/mc_mitm/source/controllers/trigger_mapper.hpp
+++ b/mc_mitm/source/controllers/trigger_mapper.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include "switch_controller.hpp"
+#include <stratosphere.hpp>
 #include <vector>
 
 namespace ams::controller {
@@ -59,11 +60,20 @@ namespace ams::controller {
             // and per-titleID overrides. Each filename is expected to be the key
             // (12-hex MAC for controllers/, 16-hex programID for titles/) with an
             // .ini extension; each file's [trigger_map] section is parsed into a
-            // complete TriggerProfile. Called once at boot, after Initialize.
+            // complete TriggerProfile. Called once at boot from LoadConfiguration,
+            // and again from the hot-reload thread on every title switch.
             void LoadDirectoryProfiles();
+
+            // Launch the background thread that waits on the existing process-switch
+            // event and re-runs LoadDirectoryProfiles on each title transition, so
+            // newly-added ini files take effect without a sysmodule restart.
+            // No-ops on second call. The thread runs for the lifetime of the sysmodule.
+            void StartHotReloadThread();
 
             // Apply the controller's currently-resolved profile to the per-packet
             // controller state. No-op when the resolved profile's mode == Off.
+            // Called from the bluetooth input thread; takes m_mutex but never performs
+            // filesystem I/O on this path.
             void Apply(const bluetooth::Address& addr,
                        SwitchButtonData& buttons,
                        SwitchAnalogStick& lstick,
@@ -72,14 +82,18 @@ namespace ams::controller {
                        u16 right_trigger_norm);
 
         private:
-            // Resolve the active profile for this controller given the currently-running
-            // title. Precedence: per-title > per-controller > global. Profile-level —
-            // whichever level matches first is returned in full, no field merging.
-            const TriggerProfile& Resolve(const bluetooth::Address& addr) const;
+            // Resolve the active profile for this controller given a specific title.
+            // Precedence: per-title > per-controller > global. Profile-level — whichever
+            // level matches first is returned in full, no field merging.
+            const TriggerProfile& Resolve(const bluetooth::Address& addr, u64 current_title) const;
+
+            // LoadDirectoryProfiles without taking m_mutex; caller must hold it.
+            void LoadDirectoryProfilesUnsafe();
 
             struct ControllerEntry { bluetooth::Address addr;     TriggerProfile profile; };
             struct TitleEntry      { u64                title_id; TriggerProfile profile; };
 
+            os::SdkMutex                 m_mutex;
             TriggerProfile               m_global;
             std::vector<ControllerEntry> m_controllers;
             std::vector<TitleEntry>      m_titles;

--- a/mc_mitm/source/mcmitm_config.cpp
+++ b/mc_mitm/source/mcmitm_config.cpp
@@ -192,6 +192,7 @@ namespace ams::mitm {
         profile.invert_y                     = g_global_config.trigger_map.invert_y;
         controller::TriggerMapper::Instance().Initialize(profile);
         controller::TriggerMapper::Instance().LoadDirectoryProfiles();
+        controller::TriggerMapper::Instance().StartHotReloadThread();
     }
 
     MissionControlConfig *GetGlobalConfig() {

--- a/mc_mitm/source/mcmitm_config.cpp
+++ b/mc_mitm/source/mcmitm_config.cpp
@@ -15,6 +15,7 @@
  */
 #include <stratosphere.hpp>
 #include "mcmitm_config.hpp"
+#include "controllers/trigger_mapper.hpp"
 
 namespace ams::mitm {
 
@@ -38,6 +39,13 @@ namespace ams::mitm {
                 .dualsense_lightbar_brightness = 5,
                 .dualsense_enable_player_leds = true,
                 .dualsense_vibration_intensity = 4
+            },
+            .trigger_map = {
+                .mode         = 0,    // off
+                .zr_threshold = 101,  // off — never fire digital ZR in this mode
+                .zl_threshold = 101,  // off
+                .deadzone     = 0,
+                .invert_y     = false
             }
         };
 
@@ -111,6 +119,30 @@ namespace ams::mitm {
                 } else if (strcasecmp(name, "dualsense_vibration_intensity") == 0) {
                     ParseInt(value, &config->misc.dualsense_vibration_intensity, 1, 8);
                 }
+            } else if (strcasecmp(section, "trigger_map") == 0) {
+                if (strcasecmp(name, "mode") == 0) {
+                    if (strcasecmp(value, "off") == 0) {
+                        config->trigger_map.mode = 0;
+                    } else if (strcasecmp(value, "rstick_y_split") == 0) {
+                        config->trigger_map.mode = 1;
+                    }
+                } else if (strcasecmp(name, "zr_threshold") == 0) {
+                    if (strcasecmp(value, "off") == 0) {
+                        config->trigger_map.zr_threshold = 101;
+                    } else {
+                        ParseInt(value, &config->trigger_map.zr_threshold, 0, 100);
+                    }
+                } else if (strcasecmp(name, "zl_threshold") == 0) {
+                    if (strcasecmp(value, "off") == 0) {
+                        config->trigger_map.zl_threshold = 101;
+                    } else {
+                        ParseInt(value, &config->trigger_map.zl_threshold, 0, 100);
+                    }
+                } else if (strcasecmp(name, "deadzone") == 0) {
+                    ParseInt(value, &config->trigger_map.deadzone, 0, 100);
+                } else if (strcasecmp(name, "invert_y") == 0) {
+                    ParseBoolean(value, &config->trigger_map.invert_y);
+                }
             } else {
                 return 0;
             }
@@ -143,6 +175,14 @@ namespace ams::mitm {
     void LoadConfiguration() {
         ParseIniConfiguration();
         ReadSystemLanguage();
+
+        controller::TriggerProfile profile;
+        profile.mode         = static_cast<controller::TriggerMode>(g_global_config.trigger_map.mode);
+        profile.zr_threshold = static_cast<u8>(g_global_config.trigger_map.zr_threshold);
+        profile.zl_threshold = static_cast<u8>(g_global_config.trigger_map.zl_threshold);
+        profile.deadzone     = static_cast<u8>(g_global_config.trigger_map.deadzone);
+        profile.invert_y     = g_global_config.trigger_map.invert_y;
+        controller::TriggerMapper::Instance().Initialize(profile);
     }
 
     MissionControlConfig *GetGlobalConfig() {

--- a/mc_mitm/source/mcmitm_config.cpp
+++ b/mc_mitm/source/mcmitm_config.cpp
@@ -183,6 +183,7 @@ namespace ams::mitm {
         profile.deadzone     = static_cast<u8>(g_global_config.trigger_map.deadzone);
         profile.invert_y     = g_global_config.trigger_map.invert_y;
         controller::TriggerMapper::Instance().Initialize(profile);
+        controller::TriggerMapper::Instance().LoadDirectoryProfiles();
     }
 
     MissionControlConfig *GetGlobalConfig() {

--- a/mc_mitm/source/mcmitm_config.cpp
+++ b/mc_mitm/source/mcmitm_config.cpp
@@ -41,11 +41,12 @@ namespace ams::mitm {
                 .dualsense_vibration_intensity = 4
             },
             .trigger_map = {
-                .mode         = 0,    // off
-                .zr_threshold = 101,  // off — never fire digital ZR in this mode
-                .zl_threshold = 101,  // off
-                .deadzone     = 0,
-                .invert_y     = false
+                .mode                         = 0,    // off
+                .zr_threshold                 = 101,  // off — never fire digital ZR in this mode
+                .zl_threshold                 = 101,  // off
+                .stick_y_to_buttons_threshold = 101,  // off
+                .deadzone                     = 0,
+                .invert_y                     = false
             }
         };
 
@@ -138,6 +139,12 @@ namespace ams::mitm {
                     } else {
                         ParseInt(value, &config->trigger_map.zl_threshold, 0, 100);
                     }
+                } else if (strcasecmp(name, "stick_y_to_buttons_threshold") == 0) {
+                    if (strcasecmp(value, "off") == 0) {
+                        config->trigger_map.stick_y_to_buttons_threshold = 101;
+                    } else {
+                        ParseInt(value, &config->trigger_map.stick_y_to_buttons_threshold, 0, 100);
+                    }
                 } else if (strcasecmp(name, "deadzone") == 0) {
                     ParseInt(value, &config->trigger_map.deadzone, 0, 100);
                 } else if (strcasecmp(name, "invert_y") == 0) {
@@ -177,11 +184,12 @@ namespace ams::mitm {
         ReadSystemLanguage();
 
         controller::TriggerProfile profile;
-        profile.mode         = static_cast<controller::TriggerMode>(g_global_config.trigger_map.mode);
-        profile.zr_threshold = static_cast<u8>(g_global_config.trigger_map.zr_threshold);
-        profile.zl_threshold = static_cast<u8>(g_global_config.trigger_map.zl_threshold);
-        profile.deadzone     = static_cast<u8>(g_global_config.trigger_map.deadzone);
-        profile.invert_y     = g_global_config.trigger_map.invert_y;
+        profile.mode                         = static_cast<controller::TriggerMode>(g_global_config.trigger_map.mode);
+        profile.zr_threshold                 = static_cast<u8>(g_global_config.trigger_map.zr_threshold);
+        profile.zl_threshold                 = static_cast<u8>(g_global_config.trigger_map.zl_threshold);
+        profile.stick_y_to_buttons_threshold = static_cast<u8>(g_global_config.trigger_map.stick_y_to_buttons_threshold);
+        profile.deadzone                     = static_cast<u8>(g_global_config.trigger_map.deadzone);
+        profile.invert_y                     = g_global_config.trigger_map.invert_y;
         controller::TriggerMapper::Instance().Initialize(profile);
         controller::TriggerMapper::Instance().LoadDirectoryProfiles();
     }

--- a/mc_mitm/source/mcmitm_config.hpp
+++ b/mc_mitm/source/mcmitm_config.hpp
@@ -38,6 +38,14 @@ namespace ams::mitm {
             bool dualsense_enable_player_leds;
             int dualsense_vibration_intensity;
         } misc;
+
+        struct {
+            int  mode;          // 0=off, 1=rstick_y_split
+            int  zr_threshold;  // 0..100
+            int  zl_threshold;  // 0..100
+            int  deadzone;      // 0..100
+            bool invert_y;
+        } trigger_map;
     };
 
     void LoadConfiguration();

--- a/mc_mitm/source/mcmitm_config.hpp
+++ b/mc_mitm/source/mcmitm_config.hpp
@@ -40,10 +40,11 @@ namespace ams::mitm {
         } misc;
 
         struct {
-            int  mode;          // 0=off, 1=rstick_y_split
-            int  zr_threshold;  // 0..100
-            int  zl_threshold;  // 0..100
-            int  deadzone;      // 0..100
+            int  mode;                          // 0=off, 1=rstick_y_split
+            int  zr_threshold;                  // 0..100, >100 = off
+            int  zl_threshold;                  // 0..100, >100 = off
+            int  stick_y_to_buttons_threshold;  // 0..100, >100 = off
+            int  deadzone;                      // 0..100
             bool invert_y;
         } trigger_map;
     };


### PR DESCRIPTION
Generalises the proof-of-concept analog-trigger remap discussed in #1006 into a fully configurable feature with per-game and per-controller overrides.

## What it does

The existing per-controller HID conversion converts analog triggers into the digital ZR/ZL bits and discards the analog value. Games like Grid Autosport read throttle / brake off the right-stick analog Y axis rather than ZR/ZL, so handing them the digital bit gives on/off throttle with no graduated control. This PR adds an opt-in post-hook to `EmulatedSwitchController::UpdateControllerState` that maps a controller's raw analog trigger value back onto the right-stick Y axis before the report is dispatched.

## Configuration

New `[trigger_map]` section in `missioncontrol.ini`:

```ini
[trigger_map]
mode = rstick_y_split    ; off | rstick_y_split  (default off)
zr_threshold = off       ; 0..100 or "off" — digital ZR fire threshold while mapping active
zl_threshold = off       ; same for ZL
deadzone = 0             ; 0..100 % on raw trigger
invert_y = false
stick_y_to_buttons_threshold = off  ; 0..100 — repurpose physical stick Y as digital ZR/ZL
```

Per-game overrides: `/config/MissionControl/titles/<16-hex-program-id>.ini`. Per-controller: `/config/MissionControl/controllers/<lowercase-MAC>.ini`. Both directories are re-scanned on every title switch (using the existing `mcmitm_process_monitor` API) so adding a game profile takes effect on next launch without a sysmodule restart. Precedence: per-title > per-controller > global, profile-level (no field merging).

## Architecture

A new `TriggerMapper` (`mc_mitm/source/controllers/trigger_mapper.{hpp,cpp}`) holds the resolved-profile state and runs after `ProcessInputData` in `EmulatedSwitchController::UpdateControllerState`. Per-controller subclasses opt in by (1) setting `m_supports_trigger_map = true` in their constructor or `Initialize`, and (2) populating `m_left_trigger_raw` / `m_right_trigger_raw` (`u16`, 0–0xFFFF) in their `MapInputReportXxx` from the controller's native trigger format. Subclasses that don't opt in are unaffected — `Apply` early-returns and the existing ZR/ZL threshold path is unchanged.

## Testing status

Hardware-verified on **DualShock 4** (via a GameSir G8 Galileo Plus emulating a DS4, in handheld mode). The `[trigger_map]` section parses correctly and the directory hot-reload behaves correctly across title switches.

Only DS4 is opted in in this PR — happy to fan out to other controllers in a follow-up once the foundation lands, with your preference on which to enable.

## Commits

Structured as five reviewable commits: (1) core feature + DS4 wiring + global config, (2) layered per-title/per-controller profiles, (3) stick-Y → digital ZR/ZL repurposing, (4) hot-reload on title switch, (5) README docs.

If you'd prefer narrower scope (e.g. just the core feature for now, follow-ups for layered config and stick-Y), happy to split.